### PR TITLE
Added reading of a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ email server, and associated logins, passwords.  search for "yourdomain",
 "password".  Search for "shortcuts" to setup email aliases as well.
 
 
+Installation:
+```
+pip install aprsd
+```
+
 Example usage:
 ```
-./aprsd.py
+aprsd -h
 ```
 
 Example output:

--- a/aprsd/main.py
+++ b/aprsd/main.py
@@ -43,7 +43,7 @@ import pprint
 from imapclient import IMAPClient, SEEN
 
 # local imports here
-from fuzzyclock import fuzzy
+from aprsd.fuzzyclock import fuzzy
 import utils
 
 # localization, please edit:
@@ -106,6 +106,10 @@ if not args.callsign:
 else:
     BASECALLSIGN = args.callsign
 
+
+# Now read the ~/.aprds/config.yml
+config = utils.get_config()
+shortcuts = config['shortcuts']
 
 try:
   tn = telnetlib.Telnet(HOST, 14580)

--- a/aprsd/main.py
+++ b/aprsd/main.py
@@ -109,7 +109,11 @@ else:
 
 # Now read the ~/.aprds/config.yml
 config = utils.get_config()
-shortcuts = config['shortcuts']
+if 'shortcuts' in config:
+    shortcuts = config['shortcuts']
+else:
+    print("missing 'shortcuts' section of config.yml")
+    sys.exit(-1)
 
 try:
   tn = telnetlib.Telnet(HOST, 14580)

--- a/aprsd/utils.py
+++ b/aprsd/utils.py
@@ -3,7 +3,27 @@
 import os
 import pprint
 import sys
+import yaml
 
+# an example of what should be in the ~/.aprsd/config.yml
+example_config = '''
+shortcuts:
+    'aa': '5551239999@vtext.com'
+    'cl': 'craiglamparter@somedomain.org'
+    'wb': '555309@vtext.com'
+
+smtp:
+    login: something
+    password: some lame password
+
+imap:
+    login: imapuser
+    password: something dumb
+
+ham:
+    callsign: something
+    basename: somebasename
+'''
 
 def env(*vars, **kwargs):
     """This returns the first environment variable set.
@@ -14,3 +34,15 @@ def env(*vars, **kwargs):
         if value:
             return value
     return kwargs.get('default', '')
+
+
+def get_config():
+    """This tries to read the yaml config from ~/.aprsd/config.yml."""
+    config_file = os.path.expanduser("~/.aprsd/config.yml")
+    if os.path.exists(config_file):
+        with open(config_file, "r") as stream:
+            config = yaml.load(stream)
+            return config
+    else:
+        print("%s is missing, please create a config file" % config_file)
+        print("example config is\n %s" % example_config)

--- a/aprsd/utils.py
+++ b/aprsd/utils.py
@@ -46,3 +46,4 @@ def get_config():
     else:
         print("%s is missing, please create a config file" % config_file)
         print("example config is\n %s" % example_config)
+        sys.exit(-1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pbr
 imapclient
+pyyaml


### PR DESCRIPTION
This patch adds support to read a ~/.aprsd/config.yml file.
If one doesn't exist, it puts out an example yaml string to stdout
that can be copied into a file and edited.

Since this patch adds a new external requirement (pyyaml) you need
to re-install the app for dev with
pip install -e .