### PR TITLE
Added port and fixed telnet user

### DIFF
--- a/aprsd/main.py
+++ b/aprsd/main.py
@@ -214,8 +214,13 @@ def check_email_thread():
               (CONFIG['imap']['host'],
                CONFIG['imap']['login']))
 
-    server = IMAPClient(CONFIG['imap']['host'], use_uid=True)
-    server.login(CONFIG['imap']['login'], CONFIG['imap']['password'])
+    try:
+        server = IMAPClient(CONFIG['imap']['host'], use_uid=True, timeout=5)
+        server.login(CONFIG['imap']['login'], CONFIG['imap']['password'])
+    except Exception:
+        LOG.exception("Failed to login with IMAP server")
+        return
+
     # select_info = server.select_folder('INBOX')
 
     messages = server.search(['SINCE', today])
@@ -460,12 +465,14 @@ def main(args=args):
 
     check_email_thread()  # start email reader thread
 
+    LOG.info("Start main loop")
     while True:
         line = ""
         try:
             for char in tn.read_until("\n",100):
                 line = line + char
             line = line.replace('\n', '')
+            print("ASS LINE %s" % line)
             LOG.info(line)
             searchstring = '::' + user
             # is aprs message to us, not beacon, status, etc

--- a/aprsd/main.py
+++ b/aprsd/main.py
@@ -89,11 +89,12 @@ args = parser.parse_args()
 def setup_connection():
     global tn
     host = CONFIG['aprs']['host']
-    LOG.debug("Setting up telnet connection to '%s'" % host)
+    port = CONFIG['aprs']['port']
+    LOG.debug("Setting up telnet connection to '%s:%s'" % (host, port))
     try:
-        tn = telnetlib.Telnet(host, 14580)
+        tn = telnetlib.Telnet(host, port)
     except Exception, e:
-        LOG.critical("Telnet session failed.\n", e)
+        LOG.exception("Telnet session failed.")
         sys.exit(-1)
 
 
@@ -430,6 +431,7 @@ def parse_config(args):
     check_option(config, 'aprs', 'login')
     check_option(config, 'aprs', 'password')
     check_option(config, 'aprs', 'host')
+    check_option(config, 'aprs', 'port')
     check_option(config, 'imap', 'host')
     check_option(config, 'imap', 'login')
     check_option(config, 'imap', 'password')
@@ -453,7 +455,7 @@ def main(args=args):
     user = CONFIG['aprs']['login']
     password = CONFIG['aprs']['password']
     LOG.info("LOGIN to APRSD with user '%s'" % user)
-    tn.write("user " + user + " pass " + password + " vers aprsd 0.99\n" )
+    tn.write("user %s pass %s vers aprsd 0.99\n" % (user, password) )
     time.sleep(2)
 
     check_email_thread()  # start email reader thread

--- a/aprsd/utils.py
+++ b/aprsd/utils.py
@@ -14,6 +14,7 @@ aprs:
     login: someusername
     password: password
     host: noam.aprs2.net
+    port: 14580
 
 shortcuts:
     'aa': '5551239999@vtext.com'


### PR DESCRIPTION
This patch adds the port to the aprs: section of the config.yml
as well as fixes a possible issue with the user telnet auth command
where the user is a string and the port is an int.  python can't
concatonate a string with an int.