### PR TITLE
Fixed the usage string after plugins introduced

### DIFF
--- a/examples/plugins/example_plugin.py
+++ b/examples/plugins/example_plugin.py
@@ -11,6 +11,7 @@ class HelloPlugin(plugin.APRSDPluginBase):
     version = "1.0"
     # matches any string starting with h or H
     command_regex = "^[hH]"
+    command_name = "hello"
 
     def command(self, fromcall, message, ack):
         LOG.info("HelloPlugin")


### PR DESCRIPTION
This patch fixes the Usage string for a call message
that isn't matched by any plugin.

Plugin object now must impleent a 'command_name' attribute
that is the usage string for that plugin.