### PR TITLE
Don't use the dirname for the plugin path search

### DIFF
--- a/aprsd/plugin.py
+++ b/aprsd/plugin.py
@@ -98,7 +98,7 @@ class PluginManager(object):
         self.config = config
 
     def load_plugins(self, module_path):
-        dir_path = os.path.dirname(os.path.realpath(module_path))
+        dir_path = os.path.realpath(module_path)
         pattern = "*.py"
 
         self.obj_list = []


### PR DESCRIPTION
This patch removes the call to dirname in the search path for plugins. 
It was failing for short paths.