### PR TITLE
Threads

### DIFF
--- a/aprsd/client.py
+++ b/aprsd/client.py
@@ -73,6 +73,7 @@ class Aprsdis(aprslib.IS):
 
     def stop(self):
         self.thread_stop = True
+        LOG.info("Shutdown Aprsdis client.")
 
     def _socket_readlines(self, blocking=False):
         """
@@ -94,7 +95,6 @@ class Aprsdis(aprslib.IS):
                 [self.sock], [], [], self.select_timeout
             )
             if not readable:
-                self.logger.info("nothing to read")
                 continue
 
             try:

--- a/aprsd/client.py
+++ b/aprsd/client.py
@@ -1,4 +1,6 @@
 import logging
+import select
+import socket
 import time
 
 import aprslib
@@ -45,7 +47,7 @@ class Client(object):
         while not connected:
             try:
                 LOG.info("Creating aprslib client")
-                aprs_client = aprslib.IS(user, passwd=password, host=host, port=port)
+                aprs_client = Aprsdis(user, passwd=password, host=host, port=port)
                 # Force the logging to be the same
                 aprs_client.logger = LOG
                 aprs_client.connect()
@@ -58,6 +60,63 @@ class Client(object):
                 continue
         LOG.debug("Logging in to APRS-IS with user '%s'" % user)
         return aprs_client
+
+
+class Aprsdis(aprslib.IS):
+    """Extend the aprslib class so we can exit properly."""
+
+    # flag to tell us to stop
+    thread_stop = False
+
+    # timeout in seconds
+    select_timeout = 10
+
+    def stop(self):
+        self.thread_stop = True
+
+    def _socket_readlines(self, blocking=False):
+        """
+        Generator for complete lines, received from the server
+        """
+        try:
+            self.sock.setblocking(0)
+        except socket.error as e:
+            self.logger.error("socket error when setblocking(0): %s" % str(e))
+            raise aprslib.ConnectionDrop("connection dropped")
+
+        while not self.thread_stop:
+            short_buf = b""
+            newline = b"\r\n"
+
+            # set a select timeout, so we get a chance to exit
+            # when user hits CTRL-C
+            readable, writable, exceptional = select.select(
+                [self.sock], [], [], self.select_timeout
+            )
+            if not readable:
+                self.logger.info("nothing to read")
+                continue
+
+            try:
+                short_buf = self.sock.recv(4096)
+
+                # sock.recv returns empty if the connection drops
+                if not short_buf:
+                    self.logger.error("socket.recv(): returned empty")
+                    raise aprslib.ConnectionDrop("connection dropped")
+            except socket.error as e:
+                # self.logger.error("socket error on recv(): %s" % str(e))
+                if "Resource temporarily unavailable" in str(e):
+                    if not blocking:
+                        if len(self.buf) == 0:
+                            break
+
+            self.buf += short_buf
+
+            while newline in self.buf:
+                line, self.buf = self.buf.split(newline, 1)
+
+                yield line
 
 
 def get_client():

--- a/aprsd/messaging.py
+++ b/aprsd/messaging.py
@@ -1,11 +1,11 @@
 import abc
 import logging
-from multiprocessing import RawValue
 import pprint
 import re
 import threading
 import time
 import uuid
+from multiprocessing import RawValue
 
 from aprsd import client
 
@@ -20,6 +20,7 @@ ack_dict = {}
 # and it's ok, but don't send a usage string back
 NULL_MESSAGE = -1
 
+
 class MessageCounter(object):
     """
     Global message id counter class.
@@ -31,13 +32,14 @@ class MessageCounter(object):
     from the MessageCounter.
 
     """
+
     _instance = None
 
     def __new__(cls, *args, **kwargs):
         """Make this a singleton class."""
         if cls._instance is None:
             cls._instance = super(MessageCounter, cls).__new__(cls)
-            cls._instance.val = RawValue('i', 1)
+            cls._instance.val = RawValue("i", 1)
             cls._instance.lock = threading.Lock()
         return cls._instance
 
@@ -61,6 +63,7 @@ class MessageCounter(object):
 
 class Message(object, metaclass=abc.ABCMeta):
     """Base Message Class."""
+
     # The message id to send over the air
     id = 0
 
@@ -102,14 +105,16 @@ class TextMessage(Message):
     def __repr__(self):
         """Build raw string to send over the air."""
         return "{}>APRS::{}:{}{{{}\n".format(
-            self.fromcall, self.tocall.ljust(9),
-            self._filter_for_send(), str(self.id),)
+            self.fromcall,
+            self.tocall.ljust(9),
+            self._filter_for_send(),
+            str(self.id),
+        )
 
     def __str__(self):
         return "From({}) TO({}) - Message({}): '{}'".format(
-                self.fromcall, self.tocall,
-                self.id, self.message
-            )
+            self.fromcall, self.tocall, self.id, self.message
+        )
 
     def ack(self):
         """Build an Ack Message object from this object."""
@@ -162,7 +167,8 @@ class TextMessage(Message):
             ack_dict.clear()
             LOG.debug(pprint.pformat(ack_dict))
             LOG.debug(
-                "DEBUG: Cleared ack dictionary, ack_dict length is now %s." % len(ack_dict)
+                "DEBUG: Cleared ack dictionary, ack_dict length is now %s."
+                % len(ack_dict)
             )
         ack_dict[self.id] = 0  # clear ack for this message number
 
@@ -173,8 +179,11 @@ class TextMessage(Message):
         """Send a message without a separate thread."""
         cl = client.get_client()
         log_message(
-            "Sending Message Direct", repr(self).rstrip("\n"), self.message, tocall=self.tocall,
-            fromcall=self.fromcall
+            "Sending Message Direct",
+            repr(self).rstrip("\n"),
+            self.message,
+            tocall=self.tocall,
+            fromcall=self.fromcall,
         )
         cl.sendall(repr(self))
 
@@ -182,19 +191,16 @@ class TextMessage(Message):
 class AckMessage(Message):
     """Class for building Acks and sending them."""
 
-
     def __init__(self, fromcall, tocall, msg_id):
         super(AckMessage, self).__init__(fromcall, tocall, msg_id=msg_id)
 
     def __repr__(self):
         return "{}>APRS::{}:ack{}\n".format(
-            self.fromcall, self.tocall.ljust(9), self.id)
+            self.fromcall, self.tocall.ljust(9), self.id
+        )
 
     def __str__(self):
-        return "From({}) TO({}) Ack ({})".format(
-            self.fromcall, self.tocall,
-            self.id
-        )
+        return "From({}) TO({}) Ack ({})".format(self.fromcall, self.tocall, self.id)
 
     def send_thread(self):
         """Separate thread to send acks with retries."""
@@ -216,10 +222,9 @@ class AckMessage(Message):
 
     def send(self):
         LOG.debug("Send ACK({}:{}) to radio.".format(self.tocall, self.id))
-        thread = threading.Thread(
-            target=self.send_thread, name="send_ack"
-        )
+        thread = threading.Thread(target=self.send_thread, name="send_ack")
         thread.start()
+
     # end send_ack()
 
     def send_direct(self):

--- a/aprsd/messaging.py
+++ b/aprsd/messaging.py
@@ -1,13 +1,12 @@
 import abc
+import datetime
 import logging
-import pprint
 import re
 import threading
 import time
-import uuid
 from multiprocessing import RawValue
 
-from aprsd import client
+from aprsd import client, threads
 
 LOG = logging.getLogger("APRSD")
 
@@ -19,6 +18,75 @@ ack_dict = {}
 # What to return from a plugin if we have processed the message
 # and it's ok, but don't send a usage string back
 NULL_MESSAGE = -1
+
+
+class MsgTrack(object):
+    """Class to keep track of outstanding text messages.
+
+    This is a thread safe class that keeps track of active
+    messages.
+
+    When a message is asked to be sent, it is placed into this
+    class via it's id.  The TextMessage class's send() method
+    automatically adds itself to this class.  When the ack is
+    recieved from the radio, the message object is removed from
+    this class.
+
+    # TODO(hemna)
+    When aprsd is asked to quit this class should be serialized and
+    saved to disk/db to keep track of the state of outstanding messages.
+    When aprsd is started, it should try and fetch the saved state,
+    and reloaded to a live state.
+
+    """
+
+    _instance = None
+    lock = None
+
+    track = {}
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(MsgTrack, cls).__new__(cls)
+            cls._instance.track = {}
+            cls._instance.lock = threading.Lock()
+        return cls._instance
+
+    def add(self, msg):
+        with self.lock:
+            key = int(msg.id)
+            self.track[key] = msg
+
+    def get(self, id):
+        with self.lock:
+            if id in self.track:
+                return self.track[id]
+
+    def remove(self, id):
+        with self.lock:
+            key = int(id)
+            if key in self.track.keys():
+                del self.track[key]
+
+    def __len__(self):
+        with self.lock:
+            return len(self.track)
+
+    def __str__(self):
+        with self.lock:
+            result = "{"
+            for key in self.track.keys():
+                result += "{}: {}, ".format(key, str(self.track[key]))
+            result += "}"
+            return result
+
+    def save(self):
+        """Save this shit to disk?"""
+        pass
+
+    def restore(self):
+        """Restore this shit?"""
+        pass
 
 
 class MessageCounter(object):
@@ -34,6 +102,7 @@ class MessageCounter(object):
     """
 
     _instance = None
+    max_count = 9999
 
     def __new__(cls, *args, **kwargs):
         """Make this a singleton class."""
@@ -45,7 +114,10 @@ class MessageCounter(object):
 
     def increment(self):
         with self.lock:
-            self.val.value += 1
+            if self.val.value == self.max_count:
+                self.val.value = 1
+            else:
+                self.val.value += 1
 
     @property
     def value(self):
@@ -67,20 +139,13 @@ class Message(object, metaclass=abc.ABCMeta):
     # The message id to send over the air
     id = 0
 
-    # Unique identifier for this message
-    uuid = None
-
-    sent = False
-    sent_time = None
-    acked = False
-    acked_time = None
-
     retry_count = 3
+    last_send_time = None
+    last_send_attempt = 0
 
     def __init__(self, fromcall, tocall, msg_id=None):
         self.fromcall = fromcall
         self.tocall = tocall
-        self.uuid = uuid.uuid4()
         if not msg_id:
             c = MessageCounter()
             c.increment()
@@ -98,9 +163,12 @@ class TextMessage(Message):
 
     message = None
 
-    def __init__(self, fromcall, tocall, message):
-        super(TextMessage, self).__init__(fromcall, tocall)
+    def __init__(self, fromcall, tocall, message, msg_id=None, allow_delay=True):
+        super(TextMessage, self).__init__(fromcall, tocall, msg_id)
         self.message = message
+        # do we try and save this message for later if we don't get
+        # an ack?  Some messages we don't want to do this ever.
+        self.allow_delay = allow_delay
 
     def __repr__(self):
         """Build raw string to send over the air."""
@@ -112,13 +180,13 @@ class TextMessage(Message):
         )
 
     def __str__(self):
-        return "From({}) TO({}) - Message({}): '{}'".format(
-            self.fromcall, self.tocall, self.id, self.message
+        delta = "Never"
+        if self.last_send_time:
+            now = datetime.datetime.now()
+            delta = now - self.last_send_time
+        return "{}>{} Msg({})({}): '{}'".format(
+            self.fromcall, self.tocall, self.id, delta, self.message
         )
-
-    def ack(self):
-        """Build an Ack Message object from this object."""
-        return AckMessage(self.fromcall, self.tocall, msg_id=self.id)
 
     def _filter_for_send(self):
         """Filter and format message string for FCC."""
@@ -130,49 +198,13 @@ class TextMessage(Message):
         # We all miss George Carlin
         return re.sub("fuck|shit|cunt|piss|cock|bitch", "****", message)
 
-    def send_thread(self):
-        cl = client.get_client()
-        for i in range(self.retry_count, 0, -1):
-            LOG.debug("DEBUG: send_message_thread msg:ack combos are: ")
-            LOG.debug(pprint.pformat(ack_dict))
-            if ack_dict[self.id] != 1:
-                log_message(
-                    "Sending Message",
-                    repr(self).rstrip("\n"),
-                    self.message,
-                    tocall=self.tocall,
-                    retry_number=i,
-                )
-                # tn.write(line)
-                cl.sendall(repr(self))
-                # decaying repeats, 31 to 93 second intervals
-                sleeptime = (self.retry_count - i + 1) * 31
-                time.sleep(sleeptime)
-            else:
-                break
-        return
-        # end send_message_thread
-
     def send(self):
         global ack_dict
 
-        # TODO(Hemna) - Need a better metchanism for this.
-        # This can nuke an ack_dict while it's still being used.
-        # FIXME FIXME
-        if len(ack_dict) > 90:
-            # empty ack dict if it's really big, could result in key error later
-            LOG.debug(
-                "DEBUG: Length of ack dictionary is big at %s clearing." % len(ack_dict)
-            )
-            ack_dict.clear()
-            LOG.debug(pprint.pformat(ack_dict))
-            LOG.debug(
-                "DEBUG: Cleared ack dictionary, ack_dict length is now %s."
-                % len(ack_dict)
-            )
-        ack_dict[self.id] = 0  # clear ack for this message number
-
-        thread = threading.Thread(target=self.send_thread, name="send_message")
+        tracker = MsgTrack()
+        tracker.add(self)
+        LOG.debug("Length of MsgTrack is {}".format(len(tracker)))
+        thread = SendMessageThread(message=self)
         thread.start()
 
     def send_direct(self):
@@ -186,6 +218,73 @@ class TextMessage(Message):
             fromcall=self.fromcall,
         )
         cl.sendall(repr(self))
+
+
+class SendMessageThread(threads.APRSDThread):
+    def __init__(self, message):
+        self.msg = message
+        name = self.msg.message[:5]
+        super(SendMessageThread, self).__init__(
+            "SendMessage-{}-{}".format(self.msg.id, name)
+        )
+
+    def loop(self):
+        """Loop until a message is acked or it gets delayed.
+
+        We only sleep for 5 seconds between each loop run, so
+        that CTRL-C can exit the app in a short period.  Each sleep
+        means the app quitting is blocked until sleep is done.
+        So we keep track of the last send attempt and only send if the
+        last send attempt is old enough.
+
+        """
+        cl = client.get_client()
+        tracker = MsgTrack()
+        # lets see if the message is still in the tracking queue
+        msg = tracker.get(self.msg.id)
+        if not msg:
+            # The message has been removed from the tracking queue
+            # So it got acked and we are done.
+            LOG.info("Message Send Complete via Ack.")
+            return False
+        else:
+            send_now = False
+            if msg.last_send_attempt == msg.retry_count:
+                # we reached the send limit, don't send again
+                # TODO(hemna) - Need to put this in a delayed queue?
+                LOG.info("Message Send Complete. Max attempts reached.")
+                return False
+
+            # Message is still outstanding and needs to be acked.
+            if msg.last_send_time:
+                # Message has a last send time tracking
+                now = datetime.datetime.now()
+                sleeptime = (msg.last_send_attempt + 1) * 31
+                delta = now - msg.last_send_time
+                if delta > datetime.timedelta(seconds=sleeptime):
+                    # It's time to try to send it again
+                    send_now = True
+            else:
+                send_now = True
+
+            if send_now:
+                # no attempt time, so lets send it, and start
+                # tracking the time.
+                log_message(
+                    "Sending Message",
+                    repr(msg).rstrip("\n"),
+                    msg.message,
+                    tocall=self.msg.tocall,
+                    retry_number=msg.last_send_attempt,
+                    msg_num=msg.id,
+                )
+                cl.sendall(repr(msg))
+                msg.last_send_time = datetime.datetime.now()
+                msg.last_send_attempt += 1
+
+            time.sleep(5)
+            # Make sure we get called again.
+            return True
 
 
 class AckMessage(Message):
@@ -222,7 +321,7 @@ class AckMessage(Message):
 
     def send(self):
         LOG.debug("Send ACK({}:{}) to radio.".format(self.tocall, self.id))
-        thread = threading.Thread(target=self.send_thread, name="send_ack")
+        thread = SendAckThread(self)
         thread.start()
 
     # end send_ack()
@@ -239,6 +338,52 @@ class AckMessage(Message):
             fromcall=self.fromcall,
         )
         cl.sendall(repr(self))
+
+
+class SendAckThread(threads.APRSDThread):
+    def __init__(self, ack):
+        self.ack = ack
+        super(SendAckThread, self).__init__("SendAck-{}".format(self.ack.id))
+
+    def loop(self):
+        """Separate thread to send acks with retries."""
+        send_now = False
+        if self.ack.last_send_attempt == self.ack.retry_count:
+            # we reached the send limit, don't send again
+            # TODO(hemna) - Need to put this in a delayed queue?
+            LOG.info("Ack Send Complete. Max attempts reached.")
+            return False
+
+        if self.ack.last_send_time:
+            # Message has a last send time tracking
+            now = datetime.datetime.now()
+
+            # aprs duplicate detection is 30 secs?
+            # (21 only sends first, 28 skips middle)
+            sleeptime = 31
+            delta = now - self.ack.last_send_time
+            if delta > datetime.timedelta(seconds=sleeptime):
+                # It's time to try to send it again
+                send_now = True
+            else:
+                LOG.debug("Still wating. {}".format(delta))
+        else:
+            send_now = True
+
+        if send_now:
+            cl = client.get_client()
+            log_message(
+                "Sending ack",
+                repr(self.ack).rstrip("\n"),
+                None,
+                ack=self.ack.id,
+                tocall=self.ack.tocall,
+                retry_number=self.ack.last_send_attempt,
+            )
+            cl.sendall(repr(self.ack))
+            self.ack.last_send_attempt += 1
+            self.ack.last_send_time = datetime.datetime.now()
+        time.sleep(5)
 
 
 def log_packet(packet):
@@ -272,6 +417,7 @@ def log_message(
     retry_number=None,
     ack=None,
     packet_type=None,
+    uuid=None,
 ):
     """
 
@@ -315,6 +461,8 @@ def log_message(
     if msg_num:
         # LOG.info("    Msg number  : {}".format(msg_num))
         log_list.append("    Msg number  : {}".format(msg_num))
+    if uuid:
+        log_list.append("    UUID        : {}".format(uuid))
     # LOG.info("    {} _______________ Complete".format(header))
     log_list.append("    {} _______________ Complete".format(header))
 

--- a/aprsd/plugin.py
+++ b/aprsd/plugin.py
@@ -31,6 +31,7 @@ CORE_PLUGINS = [
     "aprsd.plugin.FortunePlugin",
     "aprsd.plugin.LocationPlugin",
     "aprsd.plugin.PingPlugin",
+    "aprsd.plugin.QueryPlugin",
     "aprsd.plugin.TimePlugin",
     "aprsd.plugin.WeatherPlugin",
     "aprsd.plugin.VersionPlugin",
@@ -351,6 +352,22 @@ class PingPlugin(APRSDPluginBase):
             "Pong! " + str(h).zfill(2) + ":" + str(m).zfill(2) + ":" + str(s).zfill(2)
         )
         return reply.rstrip()
+
+
+class QueryPlugin(APRSDPluginBase):
+    """Query command."""
+
+    version = "1.0"
+    command_regex = r"^\?.*"
+    command_name = "query"
+
+    def command(self, fromcall, message, ack):
+        LOG.info("Query COMMAND")
+
+        tracker = messaging.MsgTrack()
+        reply = "Pending Messages ({})".format(len(tracker))
+
+        return reply
 
 
 class TimePlugin(APRSDPluginBase):

--- a/aprsd/plugin.py
+++ b/aprsd/plugin.py
@@ -367,6 +367,27 @@ class QueryPlugin(APRSDPluginBase):
         tracker = messaging.MsgTrack()
         reply = "Pending Messages ({})".format(len(tracker))
 
+        searchstring = "^" + self.config["ham"]["callsign"] + ".*"
+        # only I can do admin commands
+        if re.search(searchstring, fromcall):
+            r = re.search(r"^\?-\*", message)
+            if r is not None:
+                if len(tracker) > 0:
+                    reply = "Resend ALL Delayed msgs"
+                    LOG.debug(reply)
+                    tracker.restart_delayed()
+                else:
+                    reply = "No Delayed Msgs"
+                    LOG.debug(reply)
+                return reply
+
+            r = re.search(r"^\?-[fF]!", message)
+            if r is not None:
+                reply = "Deleting ALL Delayed msgs."
+                LOG.debug(reply)
+                tracker.flush()
+                return reply
+
         return reply
 
 

--- a/aprsd/threads.py
+++ b/aprsd/threads.py
@@ -1,0 +1,186 @@
+import logging
+import queue
+import threading
+import time
+
+import aprslib
+
+from aprsd import client, messaging, plugin
+
+LOG = logging.getLogger("APRSD")
+
+
+class APRSDThread(threading.Thread):
+    def __init__(self, name, msg_queues, config):
+        super(APRSDThread, self).__init__(name=name)
+        self.msg_queues = msg_queues
+        self.config = config
+        self.thread_stop = False
+
+    def stop(self):
+        self.thread_stop = True
+
+    def run(self):
+        while not self.thread_stop:
+            self._run()
+
+
+class APRSDRXThread(APRSDThread):
+    def __init__(self, msg_queues, config):
+        super(APRSDRXThread, self).__init__("RX_MSG", msg_queues, config)
+        self.thread_stop = False
+
+    def stop(self):
+        self.thread_stop = True
+        self.aprs.stop()
+
+    def callback(self, packet):
+        try:
+            packet = aprslib.parse(packet)
+            print(packet)
+        except (aprslib.ParseError, aprslib.UnknownFormat):
+            pass
+
+    def run(self):
+        LOG.info("Starting")
+        while not self.thread_stop:
+            aprs_client = client.get_client()
+
+            # setup the consumer of messages and block until a messages
+            try:
+                # This will register a packet consumer with aprslib
+                # When new packets come in the consumer will process
+                # the packet
+
+                # Do a partial here because the consumer signature doesn't allow
+                # For kwargs to be passed in to the consumer func we declare
+                # and the aprslib developer didn't want to allow a PR to add
+                # kwargs.  :(
+                # https://github.com/rossengeorgiev/aprs-python/pull/56
+                aprs_client.consumer(self.process_packet, raw=False, blocking=False)
+
+            except aprslib.exceptions.ConnectionDrop:
+                LOG.error("Connection dropped, reconnecting")
+                time.sleep(5)
+                # Force the deletion of the client object connected to aprs
+                # This will cause a reconnect, next time client.get_client()
+                # is called
+                client.Client().reset()
+        LOG.info("Exiting ")
+
+    def process_ack_packet(self, packet):
+        ack_num = packet.get("msgNo")
+        LOG.info("Got ack for message {}".format(ack_num))
+        messaging.log_message(
+            "ACK", packet["raw"], None, ack=ack_num, fromcall=packet["from"]
+        )
+        messaging.ack_dict.update({int(ack_num): 1})
+        return
+
+    def process_mic_e_packet(self, packet):
+        LOG.info("Mic-E Packet detected.  Currenlty unsupported.")
+        messaging.log_packet(packet)
+        return
+
+    def process_message_packet(self, packet):
+        LOG.info("Got a message packet")
+        fromcall = packet["from"]
+        message = packet.get("message_text", None)
+
+        msg_id = packet.get("msgNo", None)
+        if not msg_id:
+            msg_id = "0"
+
+        messaging.log_message(
+            "Received Message", packet["raw"], message, fromcall=fromcall, ack=msg_id
+        )
+
+        found_command = False
+        # Get singleton of the PM
+        pm = plugin.PluginManager()
+        try:
+            results = pm.run(fromcall=fromcall, message=message, ack=msg_id)
+            for reply in results:
+                found_command = True
+                # A plugin can return a null message flag which signals
+                # us that they processed the message correctly, but have
+                # nothing to reply with, so we avoid replying with a usage string
+                if reply is not messaging.NULL_MESSAGE:
+                    LOG.debug("Sending '{}'".format(reply))
+
+                    # msg = {"fromcall": fromcall, "msg": reply}
+                    msg = messaging.TextMessage(
+                        self.config["aprs"]["login"], fromcall, reply
+                    )
+                    self.msg_queues["tx"].put(msg)
+                else:
+                    LOG.debug("Got NULL MESSAGE from plugin")
+
+            if not found_command:
+                plugins = pm.get_plugins()
+                names = [x.command_name for x in plugins]
+                names.sort()
+
+                reply = "Usage: {}".format(", ".join(names))
+                # messaging.send_message(fromcall, reply)
+                msg = messaging.TextMessage(
+                    self.config["aprs"]["login"], fromcall, reply
+                )
+                self.msg_queues["tx"].put(msg)
+        except Exception as ex:
+            LOG.exception("Plugin failed!!!", ex)
+            reply = "A Plugin failed! try again?"
+            # messaging.send_message(fromcall, reply)
+            msg = messaging.TextMessage(self.config["aprs"]["login"], fromcall, reply)
+            self.msg_queues["tx"].put(msg)
+
+        # let any threads do their thing, then ack
+        # send an ack last
+        ack = messaging.AckMessage(
+            self.config["aprs"]["login"], fromcall, msg_id=msg_id
+        )
+        ack.send()
+        LOG.debug("Packet processing complete")
+
+    def process_packet(self, packet):
+        """Process a packet recieved from aprs-is server."""
+
+        LOG.debug("Process packet! {}".format(self.msg_queues))
+        try:
+            LOG.debug("Got message: {}".format(packet))
+
+            msg = packet.get("message_text", None)
+            msg_format = packet.get("format", None)
+            msg_response = packet.get("response", None)
+            if msg_format == "message" and msg:
+                # we want to send the message through the
+                # plugins
+                self.process_message_packet(packet)
+                return
+            elif msg_response == "ack":
+                self.process_ack_packet(packet)
+                return
+
+            if msg_format == "mic-e":
+                # process a mic-e packet
+                self.process_mic_e_packet(packet)
+                return
+
+        except (aprslib.ParseError, aprslib.UnknownFormat) as exp:
+            LOG.exception("Failed to parse packet from aprs-is", exp)
+
+
+class APRSDTXThread(APRSDThread):
+    def __init__(self, msg_queues, config):
+        super(APRSDTXThread, self).__init__("TX_MSG", msg_queues, config)
+
+    def run(self):
+        LOG.info("Starting")
+        while not self.thread_stop:
+            try:
+                msg = self.msg_queues["tx"].get(timeout=0.1)
+                LOG.info("TXQ: got message '{}'".format(msg))
+                msg.send()
+            except queue.Empty:
+                pass
+        LOG.info("Exiting ")

--- a/aprsd/utils.py
+++ b/aprsd/utils.py
@@ -5,6 +5,7 @@ import functools
 import os
 import sys
 import threading
+from pathlib import Path
 
 import click
 import yaml
@@ -46,7 +47,10 @@ DEFAULT_CONFIG_DICT = {
     },
 }
 
-DEFAULT_CONFIG_FILE = "~/.config/aprsd/aprsd.yml"
+home = str(Path.home())
+DEFAULT_CONFIG_DIR = "{}/.config/aprsd/".format(home)
+DEFAULT_SAVE_FILE = "{}/.config/aprsd/aprsd.p".format(home)
+DEFAULT_CONFIG_FILE = "{}/.config/aprsd/aprsd.yml".format(home)
 
 
 def synchronized(wrapped):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -12,7 +12,33 @@ from aprsd.fuzzyclock import fuzzy
 
 class testPlugin(unittest.TestCase):
     def setUp(self):
+        self.fromcall = "KFART"
+        self.ack = 1
         self.config = mock.MagicMock()
+
+    @mock.patch("shutil.which")
+    def test_fortune_fail(self, mock_which):
+        fortune_plugin = plugin.FortunePlugin(self.config)
+        mock_which.return_value = None
+        message = "fortune"
+        expected = "Fortune command not installed"
+        actual = fortune_plugin.run(self.fromcall, message, self.ack)
+        self.assertEqual(expected, actual)
+
+    @mock.patch("subprocess.Popen")
+    @mock.patch("shutil.which")
+    def test_fortune_success(self, mock_which, mock_popen):
+        fortune_plugin = plugin.FortunePlugin(self.config)
+        mock_which.return_value = "/usr/bin/games"
+
+        mock_process = mock.MagicMock()
+        mock_process.communicate.return_value = [b"Funny fortune"]
+        mock_popen.return_value = mock_process
+
+        message = "fortune"
+        expected = "Funny fortune"
+        actual = fortune_plugin.run(self.fromcall, message, self.ack)
+        self.assertEqual(expected, actual)
 
     @mock.patch("time.localtime")
     def test_Time(self, mock_time):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+import sys
+import unittest
+from unittest import mock
+
+import pytest
+
+import aprsd
+from aprsd import plugin
+from aprsd.fuzzyclock import fuzzy
+
+
+class testPlugin(unittest.TestCase):
+    def setUp(self):
+        self.config = mock.MagicMock()
+
+    @mock.patch("time.localtime")
+    def test_Time(self, mock_time):
+        fake_time = mock.MagicMock()
+        h = fake_time.tm_hour = 16
+        m = fake_time.tm_min = 12
+        s = fake_time.tm_sec = 55
+        mock_time.return_value = fake_time
+        time_plugin = plugin.TimePlugin(self.config)
+
+        fromcall = "KFART"
+        message = "location"
+        ack = 1
+
+        actual = time_plugin.run(fromcall, message, ack)
+        self.assertEqual(None, actual)
+
+        cur_time = fuzzy(h, m, 1)
+
+        message = "time"
+        expected = "{} ({}:{} PDT) ({})".format(
+            cur_time, str(h), str(m).rjust(2, "0"), message.rstrip()
+        )
+        actual = time_plugin.run(fromcall, message, ack)
+        self.assertEqual(expected, actual)
+
+    @mock.patch("time.localtime")
+    def test_Ping(self, mock_time):
+        fake_time = mock.MagicMock()
+        h = fake_time.tm_hour = 16
+        m = fake_time.tm_min = 12
+        s = fake_time.tm_sec = 55
+        mock_time.return_value = fake_time
+
+        ping = plugin.PingPlugin(self.config)
+
+        fromcall = "KFART"
+        message = "location"
+        ack = 1
+
+        result = ping.run(fromcall, message, ack)
+        self.assertEqual(None, result)
+
+        def ping_str(h, m, s):
+            return (
+                "Pong! "
+                + str(h).zfill(2)
+                + ":"
+                + str(m).zfill(2)
+                + ":"
+                + str(s).zfill(2)
+            )
+
+        message = "Ping"
+        actual = ping.run(fromcall, message, ack)
+        expected = ping_str(h, m, s)
+        self.assertEqual(expected, actual)
+
+        message = "ping"
+        actual = ping.run(fromcall, message, ack)
+        self.assertEqual(expected, actual)
+
+    def test_version(self):
+        expected = "APRSD version '{}'".format(aprsd.__version__)
+        version_plugin = plugin.VersionPlugin(self.config)
+
+        fromcall = "KFART"
+        message = "No"
+        ack = 1
+
+        actual = version_plugin.run(fromcall, message, ack)
+        self.assertEqual(None, actual)
+
+        message = "version"
+        actual = version_plugin.run(fromcall, message, ack)
+        self.assertEqual(expected, actual)
+
+        message = "Version"
+        actual = version_plugin.run(fromcall, message, ack)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Reworked the threading around consuming messages from aprs, as well as processing messages.

All threads are based off of the new APRSDThread class.   This allows for looping over the thread based thread_stop var.
When aprsd exits via CTRL-C, it loops through all outstanding threads and calls stop on them all.   Each thread stops looping when thread_stop is set to True.   This ensures that all threads can exit with the user wants aprsd to exit.

Added new MsgTrack object to replace the ack_dict, which wasn't thread safe.   the MsgTrack object can save/load it's list of messages to disk.   when aprsd exits, all threads are stopped, and MsgTrack data is pickled and saved to ~/.config/aprsd/aprsd.p file.   When aprsd server is restarted, the MsgTrack data is loaded from disk and any messages that hadn't completed the cycle of send/retry are restarted automatically. 

New QueryPlugin is created to get the list of messages in the MsgTrack queue.   QueryPlugin allows configured user to force a resend of all Delayed messages.  QueryPlugin allows configured user to force a delete/flush of all messages in MsgTrack.