### PR TITLE
add unit tests for utils and small refactor of utils

### DIFF
--- a/aprsd/utils.py
+++ b/aprsd/utils.py
@@ -95,7 +95,8 @@ def create_default_config():
 
 
 def get_config(config_file):
-    """This tries to read the yaml config from <config_file>."""
+    """This tries to read the yaml config from <config_file>.  If no file is found and
+    no file can be created, it returns an error"""
     config_file_expanded = os.path.expanduser(config_file)
     if os.path.exists(config_file_expanded):
         with open(config_file_expanded, "r") as stream:
@@ -118,7 +119,7 @@ def get_config(config_file):
             msg = "Custom config file '{}' is missing.".format(config_file)
             click.echo(msg)
 
-        sys.exit(-1)
+        return msg
 
 
 # This method tries to parse the config yaml file

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+from aprsd import utils
+
+import unittest
+
+import pytest
+
+class test_config(unittest.TestCase):
+
+    # test to validate default sections of config yaml are present
+    def test_get_config_default(self):
+        result = utils.get_config(utils.DEFAULT_CONFIG_FILE)
+        assert result.__contains__("aprs")
+        assert result.__contains__("aprsd")
+        assert result.__contains__("ham")
+        assert result.__contains__("imap")
+        assert result.__contains__("shortcuts")
+        assert result.__contains__("smtp")
+        assert len(result) == 6
+        assert isinstance(result,dict)
+
+    def test_get_config_aprsd_keys(self):
+        result = utils.get_config(utils.DEFAULT_CONFIG_FILE)
+        aprsd_keys = result["aprsd"]
+        print("\n****************")
+        assert aprsd_keys.__contains__("plugin_dir")
+        assert aprsd_keys.__contains__("enabled_plugins")
+        # if there are any critical values that need to be validated in the default aprsd config, add them here
+
+    def test_get_config_does_not_exist(self):
+        bad_file = "\\foo\\bar\\NoFile.yaml"
+        result = utils.get_config(bad_file)
+        assert result.__contains__(bad_file)


### PR DESCRIPTION
Add very basic unit tests for utils.

I had to make one small change to get_config - return an error rather than exit to make this function unit testable.  There may be some pytest command the check for an override a sys.exit() call, but I don't know how to do that.

Tested on windows and whatever linux flavor used in the pipeline