### PR TITLE
Added basic service abstraction for weather

### DIFF
--- a/aprsd/dev.py
+++ b/aprsd/dev.py
@@ -11,7 +11,7 @@ import sys
 
 # local imports here
 import aprsd
-from aprsd import client, email, plugin, utils
+from aprsd import client, email, plugin, service, utils
 import click
 import click_completion
 
@@ -185,6 +185,7 @@ def test_plugin(
         message = " ".join(message)
     LOG.info("P'{}'  F'{}'   C'{}'".format(plugin_path, fromcall, message))
     client.Client(config)
+    service.WeatherService(config)
 
     pm = plugin.PluginManager(config)
     obj = pm._create_class(plugin_path, plugin.APRSDPluginBase, config=config)

--- a/aprsd/main.py
+++ b/aprsd/main.py
@@ -32,7 +32,7 @@ import time
 
 # local imports here
 import aprsd
-from aprsd import client, email, messaging, plugin, threads, utils
+from aprsd import client, email, messaging, plugin, service, threads, utils
 import aprslib
 from aprslib.exceptions import LoginError
 import click
@@ -442,6 +442,9 @@ def server(
         # Try and load saved MsgTrack list
         LOG.debug("Loading saved MsgTrack object.")
         messaging.MsgTrack().load()
+
+    LOG.info("Loading weather service")
+    service.WeatherService(config)
 
     rx_msg_queue = queue.Queue(maxsize=20)
     tx_msg_queue = queue.Queue(maxsize=20)

--- a/aprsd/plugin.py
+++ b/aprsd/plugin.py
@@ -60,7 +60,9 @@ class APRSDPluginBase(metaclass=abc.ABCMeta):
 
     @hookimpl
     def run(self, fromcall, message, ack):
+        LOG.debug("F({}) M({})".format(fromcall, message))
         if re.search(self.command_regex, message):
+            LOG.debug("call command F{} M{}".format(fromcall, message))
             return self.command(fromcall, message, ack)
 
     @abc.abstractmethod

--- a/aprsd/plugin_utils.py
+++ b/aprsd/plugin_utils.py
@@ -1,0 +1,53 @@
+#  Utilities for plugins to use
+import logging
+
+import requests
+
+LOG = logging.getLogger("APRSD")
+
+
+def get_aprs_fi(api_key, callsign):
+    LOG.info("Fetch aprs.fi location for '{}'".format(callsign))
+    try:
+        url = (
+            "http://api.aprs.fi/api/get?"
+            "&what=loc&apikey={}&format=json"
+            "&name={}".format(api_key, callsign)
+        )
+        response = requests.get(url)
+    except Exception:
+        raise Exception("Failed to get aprs.fi location")
+    else:
+        response.raise_for_status()
+        return response
+
+
+def get_weather_gov_for_gps(lat, lon):
+    LOG.debug("Fetch station at {}, {}".format(lat, lon))
+    try:
+        url2 = (
+            "https://forecast.weather.gov/MapClick.php?lat=%s"
+            "&lon=%s&FcstType=json" % (lat, lon)
+        )
+        LOG.debug("Fetching weather '{}'".format(url2))
+        response = requests.get(url2)
+    except Exception as e:
+        LOG.error(e)
+        raise Exception("Failed to get weather")
+    else:
+        response.raise_for_status()
+        return response
+
+
+def get_weather_gov_metar(station):
+    LOG.debug("Fetch metar for station '{}'".format(station))
+    try:
+        url = "https://api.weather.gov/stations/{}/observations/latest".format(
+            station,
+        )
+        response = requests.get(url)
+    except Exception:
+        raise Exception("Failed to fetch metar")
+    else:
+        response.raise_for_status()
+        return response

--- a/aprsd/service.py
+++ b/aprsd/service.py
@@ -1,0 +1,52 @@
+#  Base services class
+# this is the service mechanism used to manage
+# weather and location services from the config.
+# There are many weather and location services
+# that we could support.
+import abc
+import logging
+
+from aprsd import utils, weather
+
+LOG = logging.getLogger("APRSD")
+
+
+class APRSDService(metaclass=abc.ABCMeta):
+
+    config = None
+
+    def __init__(self, config):
+        LOG.debug("Service set config")
+        self.config = config
+        self.load()
+
+    @abc.abstractmethod
+    def load(self):
+        """Load and configure the service"""
+        pass
+
+
+class WeatherService(APRSDService):
+    _instance = None
+    wx = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            # Put any init here
+        return cls._instance
+
+    def load(self):
+        """Load the correct weather """
+        wx_shortcut = self.config["aprsd"]["services"].get(
+            "weather",
+            weather.DEFAULT_PROVIDER,
+        )
+        wx_class = weather.PROVIDER_MAPPING[wx_shortcut]
+        self.wx = utils.create_class(wx_class, weather.APRSDWeather, config=self.config)
+
+    def forecast_short(self, lat, lon):
+        return self.wx.forecast_short(lat, lon)
+
+    def forecast_raw(self, lat, lon):
+        return self.wx.forecast_raw(lat, lon)

--- a/aprsd/weather.py
+++ b/aprsd/weather.py
@@ -1,0 +1,66 @@
+import abc
+import json
+import logging
+
+import requests
+
+LOG = logging.getLogger("APRSD")
+
+DEFAULT_PROVIDER = "us-gov"
+PROVIDER_MAPPING = {
+    "us-gov": "aprsd.weather.USWeatherGov",
+}
+
+
+class APRSDWeather(metaclass=abc.ABCMeta):
+    confg = None
+
+    def __init__(self, config):
+        self.config = config
+
+    @abc.abstractmethod
+    def forecast_raw(self, lat, lon):
+        """Get a raw forecast json for latitude, longitude.
+
+        The format of the json response is entirely
+        depentent on the service itself.
+        """
+        pass
+
+    @abc.abstractmethod
+    def forecast_short(self, lat, lon):
+        """Get a short form forecast for latitude, longitude."""
+        pass
+
+
+class USWeatherGov(APRSDWeather):
+    def forecast_raw(self, lat, lon):
+        LOG.debug("Fetch station at {}, {}".format(lat, lon))
+        try:
+            url2 = (
+                "https://forecast.weather.gov/MapClick.php?lat=%s"
+                "&lon=%s&FcstType=json" % (lat, lon)
+            )
+            LOG.debug("Fetching weather '{}'".format(url2))
+            response = requests.get(url2)
+        except Exception as e:
+            LOG.error(e)
+            raise Exception("Failed to get weather")
+        else:
+            response.raise_for_status()
+            return json.loads(response.text)
+
+    def forecast_short(self, lat, lon):
+        """Return a short string for the forecast."""
+        wx_data = self.forecast_raw(lat, lon)
+        reply = (
+            "{}F({}F/{}F) {}. {}, {}.".format(
+                wx_data["currentobservation"]["Temp"],
+                wx_data["data"]["temperature"][0],
+                wx_data["data"]["temperature"][1],
+                wx_data["data"]["weather"][0],
+                wx_data["time"]["startPeriodName"][1],
+                wx_data["data"]["weather"][1],
+            )
+        ).rstrip()
+        return reply


### PR DESCRIPTION
Since there are many weather services that provide an API
for fetching weather, and some don't work in other countries,
this patch adds a new service abstraction for weather.

the user configures which weather service they want to use in the config
file, then that service is loaded at start time, and the weather plugin
uses the WeatherService object to fetch the weather for a lat,lon combo.
The WeatherService itself calls the configured service object that
fetches and returns the weather.   There is only 1 weather service
in this patch, which is the same as it used to be.  calling
forecast.weather.gov, which is a US government API.