### PR TITLE
Fixed TimePlugin timezone issue

### DIFF
--- a/aprsd/plugins/time.py
+++ b/aprsd/plugins/time.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from aprsd import fuzzyclock, plugin
+import pytz
 
 LOG = logging.getLogger("APRSD")
 
@@ -13,16 +14,34 @@ class TimePlugin(plugin.APRSDPluginBase):
     command_regex = "^[tT]"
     command_name = "time"
 
+    def _get_local_tz(self):
+        return pytz.timezone(time.strftime("%Z"))
+
+    def _get_utcnow(self):
+        return pytz.datetime.datetime.utcnow()
+
     def command(self, fromcall, message, ack):
         LOG.info("TIME COMMAND")
-        stm = time.localtime()
-        h = stm.tm_hour
-        m = stm.tm_min
-        cur_time = fuzzyclock.fuzzy(h, m, 1)
-        reply = "{} ({}:{} PDT) ({})".format(
+        # So we can mock this in unit tests
+        localzone = self._get_local_tz()
+
+        # This is inefficient for now, but this enables
+        # us to add the ability to provide time in the TZ
+        # of the caller, if we can get the TZ from their callsign location
+        # This also accounts for running aprsd in different timezones
+        utcnow = self._get_utcnow()
+        gmt_t = pytz.utc.localize(utcnow)
+        local_t = gmt_t.astimezone(localzone)
+
+        local_short_str = local_t.strftime("%H:%M %Z")
+        local_hour = local_t.strftime("%H")
+        local_min = local_t.strftime("%M")
+        cur_time = fuzzyclock.fuzzy(int(local_hour), int(local_min), 1)
+
+        reply = "{} ({}) ({})".format(
             cur_time,
-            str(h),
-            str(m).rjust(2, "0"),
+            local_short_str,
             message.rstrip(),
         )
+
         return reply

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -160,7 +160,7 @@ typing-extensions==3.7.4.3
     #   mypy
 urllib3==1.26.2
     # via requests
-virtualenv==20.2.2
+virtualenv==20.4.0
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ thesmuggler
 aprslib
 py3-validate-email
 pre-commit
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,13 +28,13 @@ filelock==3.0.12
     # via
     #   py3-validate-email
     #   virtualenv
-identify==1.5.11
+identify==1.5.13
     # via pre-commit
 idna==2.10
     # via
     #   py3-validate-email
     #   requests
-imapclient==2.1.0
+imapclient==2.2.0
     # via -r requirements.in
 jinja2==2.11.2
     # via click-completion
@@ -49,6 +49,8 @@ pluggy==0.13.1
 pre-commit==2.9.3
     # via -r requirements.in
 py3-validate-email==0.2.12
+    # via -r requirements.in
+pytz==2020.5
     # via -r requirements.in
 pyyaml==5.3.1
     # via
@@ -70,5 +72,5 @@ toml==0.10.2
     # via pre-commit
 urllib3==1.26.2
     # via requests
-virtualenv==20.2.2
+virtualenv==20.4.0
     # via pre-commit


### PR DESCRIPTION
The existing time plugin had a hard coded PDT for pacific timezone,
when it wasn't.   This patch adds some real timezone conversion from
utc to the tz of the running aprsd server.   This will eventually allow
us to use either the tz of the running aprsd and/or the tz of the
calling callsign if we can just get the tz string from the location
beacon of the caller's callsign.