### PR TITLE
Allow email to be disabled.

### DIFF
--- a/aprsd/plugins/email.py
+++ b/aprsd/plugins/email.py
@@ -21,6 +21,9 @@ class EmailPlugin(plugin.APRSDPluginBase):
     def command(self, fromcall, message, ack):
         LOG.info("Email COMMAND")
         reply = None
+        if not self.config["aprsd"]["email"].get("enabled", False):
+            LOG.debug("Email is not enabled in config file ignoring.")
+            return "Email not enabled."
 
         searchstring = "^" + self.config["ham"]["callsign"] + ".*"
         # only I can do email


### PR DESCRIPTION
The config file defaults to email being off now.  This requires
the user to set the email settings anyway, so the default is off.