### PR TITLE
Dump out the config during startup

### DIFF
--- a/aprsd/main.py
+++ b/aprsd/main.py
@@ -445,6 +445,7 @@ def server(
 
     if not quiet:
         click.echo("Load config")
+
     config = utils.parse_config(config_file)
 
     # Force setting the config to the modules that need it
@@ -459,6 +460,14 @@ def server(
         LOG.warning(msg)
     else:
         LOG.info(msg)
+
+    flat_config = utils.flatten_dict(config)
+    LOG.info("Using CONFIG values:")
+    for x in flat_config:
+        if "password" in x or "aprsd.web.users.admin" in x:
+            LOG.info("{} = XXXXXXXXXXXXXXXXXXX".format(x))
+        else:
+            LOG.info("{} = {}".format(x, flat_config[x]))
 
     if config["aprsd"].get("trace", False):
         trace.setup_tracing(["method", "api"])

--- a/aprsd/utils.py
+++ b/aprsd/utils.py
@@ -1,5 +1,6 @@
 """Utilities and helper functions."""
 
+import collections
 import errno
 import functools
 import logging
@@ -394,3 +395,15 @@ def _check_version():
         # Lets put up an error and move on.  We might not
         # have internet in this aprsd deployment.
         return 1, "Couldn't check for new version of APRSD"
+
+
+def flatten_dict(d, parent_key="", sep="."):
+    """Flatten a dict to key.key.key = value."""
+    items = []
+    for k, v in d.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, collections.MutableMapping):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)


### PR DESCRIPTION
This patch adds the dumping out of a flattened config to the log
at startup.  This is helpful for seeing what aprsd server is actually
using for config entries at startup and since it's in the log, you can
reference it.


```
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] Using CONFIG values: - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:465]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] ham.callsign = KO4KWC - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprs.login = KO4KWC-13 - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprs.password = XXXXXXXXXXXXXXXXXXX - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:468]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprs.host = noam.aprs2.net - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprs.port = 14580 - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprs.logfile = /tmp/aprsd.log - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.trace = True - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.web.enabled = True - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.web.host = 0.0.0.0 - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.web.port = 8001 - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.web.users.admin = XXXXXXXXXXXXXXXXXXX - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:468]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.enabled = True - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.shortcuts.cl = craiglamparter@somedomain.org - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.shortcuts.wb = waboring@hemna.com - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.smtp.login = test@hemna.com - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.smtp.password = XXXXXXXXXXXXXXXXXXX - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:468]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.smtp.host = smtp.gmail.com - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.smtp.port = 465 - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.smtp.use_ssl = True - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.imap.login = test@hemna.com - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.imap.password = XXXXXXXXXXXXXXXXXXX - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:468]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.imap.host = imap.gmail.com - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.imap.port = 993 - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.email.imap.use_ssl = True - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.enabled_plugins = ['aprsd.plugins.email.EmailPlugin', 'aprsd.plugins.fortune.FortunePlugin', 'aprsd.plugins.location.LocationPlugin', 'aprsd.plugins.ping.PingPlugin', 'aprsd.plugins.query.QueryPlugin', 'aprsd.plugins.weather.OWMWeatherPlugin', 'aprsd.plugins.version.VersionPlugin', 'aprsd.plugins.time.TimeOWMPlugin', 'aprsd_slack_plugin.aprsd_slack_plugin.SlackCommandPlugin'] - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
[07/05/2021 10:59:21 AM] [MainThread  ] [INFO ] aprsd.units = imperial - [/Users/i530566/devel/mine/aprsd/aprsd/main.py:470]
```