### PR TITLE
Refactor the plugin interface and manager

### DIFF
--- a/aprsd/client.py
+++ b/aprsd/client.py
@@ -226,7 +226,7 @@ class Aprsdis(aprslib.IS):
             except ParseError as exp:
                 self.logger.log(11, "%s\n    Packet: %s", exp.args[0], exp.args[1])
             except UnknownFormat as exp:
-                self.logger.log(9, "%s\n    Packet: %s", exp.args[0], exp.args[1])
+                self.logger.log(9, "unknown format %s", exp.args)
             except LoginError as exp:
                 self.logger.error("%s: %s", exp.__class__.__name__, exp.args[0])
             except (KeyboardInterrupt, SystemExit):

--- a/aprsd/messaging.py
+++ b/aprsd/messaging.py
@@ -186,11 +186,12 @@ class MessageCounter:
 
     _instance = None
     max_count = 9999
+    lock = None
 
     def __new__(cls, *args, **kwargs):
         """Make this a singleton class."""
         if cls._instance is None:
-            cls._instance = super().__new__(cls)
+            cls._instance = super().__new__(cls, *args, **kwargs)
             cls._instance.val = RawValue("i", 1)
             cls._instance.lock = threading.Lock()
         return cls._instance

--- a/aprsd/packets.py
+++ b/aprsd/packets.py
@@ -4,6 +4,10 @@ import time
 
 LOG = logging.getLogger("APRSD")
 
+PACKET_TYPE_MESSAGE = "message"
+PACKET_TYPE_ACK = "ack"
+PACKET_TYPE_MICE = "mic-e"
+
 
 class PacketList:
     """Class to track all of the packets rx'd and tx'd by aprsd."""
@@ -28,3 +32,17 @@ class PacketList:
             now = time.time()
             ts = str(now).split(".")[0]
             self.packet_list[ts] = packet
+
+
+def get_packet_type(packet):
+    """Decode the packet type from the packet."""
+
+    msg_format = packet.get("format", None)
+    msg_response = packet.get("response", None)
+    if msg_format == "message":
+        packet_type = PACKET_TYPE_MESSAGE
+    elif msg_response == "ack":
+        packet_type = PACKET_TYPE_ACK
+    elif msg_format == "mic-e":
+        packet_type = PACKET_TYPE_MICE
+    return packet_type

--- a/aprsd/plugins/email.py
+++ b/aprsd/plugins/email.py
@@ -7,7 +7,7 @@ from aprsd import email, messaging, plugin, trace
 LOG = logging.getLogger("APRSD")
 
 
-class EmailPlugin(plugin.APRSDPluginBase):
+class EmailPlugin(plugin.APRSDMessagePluginBase):
     """Email Plugin."""
 
     version = "1.0"
@@ -19,8 +19,13 @@ class EmailPlugin(plugin.APRSDPluginBase):
     email_sent_dict = {}
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("Email COMMAND")
+
+        fromcall = packet.get("from")
+        message = packet.get("message_text", None)
+        ack = packet.get("msgNo", "0")
+
         reply = None
         if not self.config["aprsd"]["email"].get("enabled", False):
             LOG.debug("Email is not enabled in config file ignoring.")

--- a/aprsd/plugins/fortune.py
+++ b/aprsd/plugins/fortune.py
@@ -7,7 +7,7 @@ from aprsd import plugin, trace
 LOG = logging.getLogger("APRSD")
 
 
-class FortunePlugin(plugin.APRSDPluginBase):
+class FortunePlugin(plugin.APRSDMessagePluginBase):
     """Fortune."""
 
     version = "1.0"
@@ -15,8 +15,13 @@ class FortunePlugin(plugin.APRSDPluginBase):
     command_name = "fortune"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("FortunePlugin")
+
+        # fromcall = packet.get("from")
+        # message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
+
         reply = None
 
         fortune_path = shutil.which("fortune")

--- a/aprsd/plugins/location.py
+++ b/aprsd/plugins/location.py
@@ -7,7 +7,7 @@ from aprsd import plugin, plugin_utils, trace, utils
 LOG = logging.getLogger("APRSD")
 
 
-class LocationPlugin(plugin.APRSDPluginBase):
+class LocationPlugin(plugin.APRSDMessagePluginBase):
     """Location!"""
 
     version = "1.0"
@@ -15,8 +15,12 @@ class LocationPlugin(plugin.APRSDPluginBase):
     command_name = "location"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("Location Plugin")
+        fromcall = packet.get("from")
+        message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
+
         # get last location of a callsign, get descriptive name from weather service
         try:
             utils.check_config_option(self.config, ["services", "aprs.fi", "apiKey"])

--- a/aprsd/plugins/notify.py
+++ b/aprsd/plugins/notify.py
@@ -1,0 +1,23 @@
+import logging
+
+from aprsd import packets, plugin, trace
+
+LOG = logging.getLogger("APRSD")
+
+
+class BaseNotifyPlugin(plugin.APRSDNotificationPluginBase):
+    """Notification base plugin."""
+
+    version = "1.0"
+
+    @trace.trace
+    def notify(self, packet):
+        LOG.info("BaseNotifyPlugin")
+
+        notify_callsign = self.config["aprsd"]["watch_list"]["alert_callsign"]
+        fromcall = packet.get("from")
+
+        packet_type = packets.get_packet_type(packet)
+        # we shouldn't notify the alert user that they are online.
+        if fromcall != notify_callsign:
+            return "{} was just seen by type:'{}'".format(fromcall, packet_type)

--- a/aprsd/plugins/ping.py
+++ b/aprsd/plugins/ping.py
@@ -6,7 +6,7 @@ from aprsd import plugin, trace
 LOG = logging.getLogger("APRSD")
 
 
-class PingPlugin(plugin.APRSDPluginBase):
+class PingPlugin(plugin.APRSDMessagePluginBase):
     """Ping."""
 
     version = "1.0"
@@ -14,8 +14,11 @@ class PingPlugin(plugin.APRSDPluginBase):
     command_name = "ping"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("PINGPlugin")
+        # fromcall = packet.get("from")
+        # message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
         stm = time.localtime()
         h = stm.tm_hour
         m = stm.tm_min

--- a/aprsd/plugins/query.py
+++ b/aprsd/plugins/query.py
@@ -7,7 +7,7 @@ from aprsd import messaging, plugin, trace
 LOG = logging.getLogger("APRSD")
 
 
-class QueryPlugin(plugin.APRSDPluginBase):
+class QueryPlugin(plugin.APRSDMessagePluginBase):
     """Query command."""
 
     version = "1.0"
@@ -15,8 +15,12 @@ class QueryPlugin(plugin.APRSDPluginBase):
     command_name = "query"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("Query COMMAND")
+
+        fromcall = packet.get("from")
+        message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
 
         tracker = messaging.MsgTrack()
         now = datetime.datetime.now()

--- a/aprsd/plugins/stock.py
+++ b/aprsd/plugins/stock.py
@@ -7,7 +7,7 @@ import yfinance as yf
 LOG = logging.getLogger("APRSD")
 
 
-class StockPlugin(plugin.APRSDPluginBase):
+class StockPlugin(plugin.APRSDMessagePluginBase):
     """Stock market plugin for fetching stock quotes"""
 
     version = "1.0"
@@ -15,8 +15,12 @@ class StockPlugin(plugin.APRSDPluginBase):
     command_name = "stock"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("StockPlugin")
+
+        # fromcall = packet.get("from")
+        message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
 
         a = re.search(r"^.*\s+(.*)", message)
         if a is not None:

--- a/aprsd/plugins/time.py
+++ b/aprsd/plugins/time.py
@@ -8,7 +8,7 @@ import pytz
 LOG = logging.getLogger("APRSD")
 
 
-class TimePlugin(plugin.APRSDPluginBase):
+class TimePlugin(plugin.APRSDMessagePluginBase):
     """Time command."""
 
     version = "1.0"
@@ -39,7 +39,7 @@ class TimePlugin(plugin.APRSDPluginBase):
         return reply
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("TIME COMMAND")
         # So we can mock this in unit tests
         localzone = self._get_local_tz()
@@ -54,7 +54,11 @@ class TimeOpenCageDataPlugin(TimePlugin):
     command_name = "Time"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
+        fromcall = packet.get("from")
+        # message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
+
         api_key = self.config["services"]["aprs.fi"]["apiKey"]
         try:
             aprs_data = plugin_utils.get_aprs_fi(api_key, fromcall)
@@ -95,7 +99,10 @@ class TimeOWMPlugin(TimePlugin):
     command_name = "Time"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
+        fromcall = packet.get("from")
+        # message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
         api_key = self.config["services"]["aprs.fi"]["apiKey"]
         try:
             aprs_data = plugin_utils.get_aprs_fi(api_key, fromcall)

--- a/aprsd/plugins/version.py
+++ b/aprsd/plugins/version.py
@@ -6,7 +6,7 @@ from aprsd import plugin, stats, trace
 LOG = logging.getLogger("APRSD")
 
 
-class VersionPlugin(plugin.APRSDPluginBase):
+class VersionPlugin(plugin.APRSDMessagePluginBase):
     """Version of APRSD Plugin."""
 
     version = "1.0"
@@ -18,8 +18,11 @@ class VersionPlugin(plugin.APRSDPluginBase):
     email_sent_dict = {}
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("Version COMMAND")
+        # fromcall = packet.get("from")
+        # message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
         stats_obj = stats.APRSDStats()
         s = stats_obj.stats()
         return "APRSD ver:{} uptime:{}".format(

--- a/aprsd/plugins/weather.py
+++ b/aprsd/plugins/weather.py
@@ -8,7 +8,7 @@ import requests
 LOG = logging.getLogger("APRSD")
 
 
-class USWeatherPlugin(plugin.APRSDPluginBase):
+class USWeatherPlugin(plugin.APRSDMessagePluginBase):
     """USWeather Command
 
     Returns a weather report for the calling weather station
@@ -26,8 +26,11 @@ class USWeatherPlugin(plugin.APRSDPluginBase):
     command_name = "weather"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
         LOG.info("Weather Plugin")
+        fromcall = packet.get("from")
+        # message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
         try:
             utils.check_config_option(self.config, ["services", "aprs.fi", "apiKey"])
         except Exception as ex:
@@ -66,7 +69,7 @@ class USWeatherPlugin(plugin.APRSDPluginBase):
         return reply
 
 
-class USMetarPlugin(plugin.APRSDPluginBase):
+class USMetarPlugin(plugin.APRSDMessagePluginBase):
     """METAR Command
 
     This provides a METAR weather report from a station near the caller
@@ -86,7 +89,10 @@ class USMetarPlugin(plugin.APRSDPluginBase):
     command_name = "Metar"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
+        fromcall = packet.get("from")
+        message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
         LOG.info("WX Plugin '{}'".format(message))
         a = re.search(r"^.*\s+(.*)", message)
         if a is not None:
@@ -154,7 +160,7 @@ class USMetarPlugin(plugin.APRSDPluginBase):
         return reply
 
 
-class OWMWeatherPlugin(plugin.APRSDPluginBase):
+class OWMWeatherPlugin(plugin.APRSDMessagePluginBase):
     """OpenWeatherMap Weather Command
 
     This provides weather near the caller or callsign.
@@ -178,7 +184,10 @@ class OWMWeatherPlugin(plugin.APRSDPluginBase):
     command_name = "Weather"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
+        fromcall = packet.get("from")
+        message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
         LOG.info("OWMWeather Plugin '{}'".format(message))
         a = re.search(r"^.*\s+(.*)", message)
         if a is not None:
@@ -271,7 +280,7 @@ class OWMWeatherPlugin(plugin.APRSDPluginBase):
         return reply
 
 
-class AVWXWeatherPlugin(plugin.APRSDPluginBase):
+class AVWXWeatherPlugin(plugin.APRSDMessagePluginBase):
     """AVWXWeatherMap Weather Command
 
     Fetches a METAR weather report for the nearest
@@ -299,7 +308,10 @@ class AVWXWeatherPlugin(plugin.APRSDPluginBase):
     command_name = "Weather"
 
     @trace.trace
-    def command(self, fromcall, message, ack):
+    def command(self, packet):
+        fromcall = packet.get("from")
+        message = packet.get("message_text", None)
+        # ack = packet.get("msgNo", "0")
         LOG.info("OWMWeather Plugin '{}'".format(message))
         a = re.search(r"^.*\s+(.*)", message)
         if a is not None:

--- a/aprsd/stats.py
+++ b/aprsd/stats.py
@@ -33,6 +33,7 @@ class APRSDStats:
 
     _mem_current = 0
     _mem_peak = 0
+    _watch_list = {}
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -169,6 +170,15 @@ class APRSDStats:
         with self.lock:
             self._email_thread_last_time = datetime.datetime.now()
 
+    @property
+    def watch_list(self):
+        with self.lock:
+            return self._watch_list
+
+    def update_watch_list(self, watch_list):
+        with self.lock:
+            self._watch_list = watch_list
+
     def stats(self):
         now = datetime.datetime.now()
         if self._email_thread_last_time:
@@ -182,7 +192,7 @@ class APRSDStats:
             last_aprsis_keepalive = "never"
 
         pm = plugin.PluginManager()
-        plugins = pm.get_plugins()
+        plugins = pm.get_msg_plugins()
         plugin_stats = {}
 
         def full_name_with_qualname(obj):
@@ -202,6 +212,7 @@ class APRSDStats:
                 "memory_current_str": utils.human_size(self.memory),
                 "memory_peak": self.memory_peak,
                 "memory_peak_str": utils.human_size(self.memory_peak),
+                "watch_list": self.watch_list,
             },
             "aprs-is": {
                 "server": self.aprsis_server,

--- a/aprsd/web/static/js/charts.js
+++ b/aprsd/web/static/js/charts.js
@@ -177,7 +177,7 @@ function updateQuadData(chart, label, first, second, third, fourth) {
 
 function update_stats( data ) {
     $("#version").text( data["stats"]["aprsd"]["version"] );
-    $("#aprsis").text( "APRS-IS Server: " + data["stats"]["aprs-is"]["server"] );
+    $("#aprsis").html( "APRS-IS Server: <a href='http://status.aprs2.net' >" + data["stats"]["aprs-is"]["server"] + "</a>" );
     $("#uptime").text( "uptime: " + data["stats"]["aprsd"]["uptime"] );
     const html_pretty = Prism.highlight(JSON.stringify(data, null, '\t'), Prism.languages.json, 'json');
     $("#jsonstats").html(html_pretty);
@@ -185,6 +185,16 @@ function update_stats( data ) {
     updateQuadData(message_chart, short_time, data["stats"]["messages"]["sent"], data["stats"]["messages"]["recieved"], data["stats"]["messages"]["ack_sent"], data["stats"]["messages"]["ack_recieved"]);
     updateDualData(email_chart, short_time, data["stats"]["email"]["sent"], data["stats"]["email"]["recieved"]);
     updateDualData(memory_chart, short_time, data["stats"]["aprsd"]["memory_peak"], data["stats"]["aprsd"]["memory_current"]);
+
+    // Update the watch list
+    var watchdiv = $("#watchDiv");
+    var html_str = '<table class="ui celled striped table"><thead><tr><th>HAM Callsign</th><th>Age since last seen by APRSD</th></tr></thead><tbody>'
+    watchdiv.html('')
+    jQuery.each(data["stats"]["aprsd"]["watch_list"], function(i, val) {
+        html_str += '<tr><td class="collapsing"><i class="phone volume icon"></i>' + i + '</td><td>' + val + '</td></tr>'
+    });
+    html_str += "</tbody></table>";
+    watchdiv.append(html_str);
 }
 
 

--- a/aprsd/web/templates/index.html
+++ b/aprsd/web/templates/index.html
@@ -68,6 +68,7 @@
         <div class="ui top attached tabular menu">
             <div class="active item" data-tab="charts-tab">Charts</div>
             <div class="item" data-tab="msgs-tab">Messages</div>
+            <div class="item" data-tab="watch-tab">Watch List</div>
             <div class="item" data-tab="config-tab">Config</div>
         </div>
 
@@ -92,6 +93,15 @@
           <div class="ui styled fluid accordion" id="accordion">
               <div id="packetsDiv" class="ui mini text">Loading</div>
           </div>
+        </div>
+
+        <div class="ui bottom attached tab segment" data-tab="watch-tab">
+            <h3 class="ui dividing header">
+                Callsign Watch List (<span id="watch_count">{{ watch_count }}</span>)
+                &nbsp;&nbsp;&nbsp;
+                Notification age - <span id="watch_age">{{ watch_age }}</span>
+            </h3>
+            <div id="watchDiv" class="ui mini text">Loading</div>
         </div>
 
         <div class="ui bottom attached tab segment" data-tab="config-tab">

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ packages =
 [entry_points]
 console_scripts =
     aprsd = aprsd.main:main
+    aprsd-listen = aprsd.listen:main
     aprsd-dev = aprsd.dev:main
     aprsd-healthcheck = aprsd.healthcheck:main
     fake_aprs = aprsd.fake_aprs:main


### PR DESCRIPTION
Add new watchlist feature
This patch adds a new optional feature called Watch list.
Aprsd will filter IN all aprs packets from a list of callsigns.
APRSD will keep track of the last time a callsign has been seen.
When the configured timeout value has been reached, the next time
a callsign is seen, APRSD will send the next packet from that callsign
through the new notification plugins list.

The new BaseNotifyPlugin is the default core APRSD notify based plugin.
When it gets a packet it will construct a reply message to be sent
to the configured alert callsign to alert them that the seen callsign
is now on the APRS network.

This basically acts as a notification that your watched callsign list is
available on APRS.

The new configuration options:
aprsd:
    watch_list:
        # The callsign to send a message to once a watch list callsign
        # is now seen on APRS-IS
        alert_callsign: NOCALL
        # The time in seconds to wait for notification.
        # The default is 12 hours.
        alert_time_seconds: 43200
        # The list of callsigns to watch for
        callsigns:
          - WB4BOR
          - KFART
        # Enable/disable this feature
        enabled: false
        # The list of notify based plugins to load for
        # processing a new seen packet from a callsign.
        enabled_plugins:
        - aprsd.plugins.notify.BaseNotifyPlugin

This patch also adds a new section in the Admin UI for showing the
watch list and the age of the last seen packet for each callsing since
APRSD startup.