### PR TITLE
Added LOG_LEVEL env variable for the docker

### DIFF
--- a/docker/bin/run.sh
+++ b/docker/bin/run.sh
@@ -13,6 +13,12 @@ if [ ! -z "${APRSD_PLUGINS}" ]; then
     done
 fi
 
+if [ -z "${LOG_LEVEL}" ] || [[ ! "${LOG_LEVEL}" =~ ^(CRITICAL|ERROR|WARNING|INFO)$ ]]; then
+    LOG_LEVEL="DEBUG"
+fi
+
+echo "Log level is set to ${LOG_LEVEL}";
+
 # check to see if there is a config file
 APRSD_CONFIG="/config/aprsd.yml"
 if [ ! -e "$APRSD_CONFIG" ]; then
@@ -20,4 +26,4 @@ if [ ! -e "$APRSD_CONFIG" ]; then
     aprsd sample-config > $APRSD_CONFIG
 fi
 
-exec aprsd server -c $APRSD_CONFIG --loglevel DEBUG
+exec aprsd server -c $APRSD_CONFIG --loglevel ${LOG_LEVEL}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,3 +9,4 @@ services:
     environment:
         - TZ=America/New_York
         - APRS_PLUGINS=aprsd-slack-plugin>=1.0.2
+        - LOG_LEVEL=ERROR


### PR DESCRIPTION
Added a LOG_LEVEL env variable to the docker run.sh file. If you set the LOG_LEVEL env variable to CRITICAL|ERROR|WARNING|INFO, it will set it to one of those. If not it will default to DEBUG. 
I also added the LOG_LEVEL in the docker_compose.yml file as ERROR level. 

Cheers!
Emre
