### PR TITLE
Fix typo on exception

### DIFF
--- a/aprsd/config.py
+++ b/aprsd/config.py
@@ -183,7 +183,7 @@ class Config(collections.UserDict):
         if val == default_fail:
             # We have to fail and bail if the user hasn't edited
             # this config option.
-            raise exception.ConfigOptionBogusDefault(path, default_fail)
+            raise exception.ConfigOptionBogusDefaultException(path, default_fail)
 
 
 def add_config_comments(raw_yaml):


### PR DESCRIPTION
On the current master branch there is a typo in `aprsd/config.py`. When attempting to run ```aprsd server``` the following error occurs:

```AttributeError("module 'aprsd.exception' has no attribute 'ConfigOptionBogusDefault'")
```
After fixing the typo addressed in this PR, the application behaves as expected with a freshly generated sample config:

```ConfigOptionBogusDefaultException('ham.callsign', 'NOCALL')```
