### PR TITLE
Allow web interface when running in Docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   aprsd:
     image: hemna6969/aprsd:latest
     container_name: aprsd
+    ports:
+        - "8001:8001"
     volumes:
         - $HOME/.config/aprsd:/config
     restart: unless-stopped


### PR DESCRIPTION
The current docker-compose.yml does not forward port 8001 to allow access to the web interface. This PR updates the docker-compose.yml file to allow access.