### PR TITLE
Fix #92 (PyPI scraping)

### DIFF
--- a/aprsd/cmds/list_plugins.py
+++ b/aprsd/cmds/list_plugins.py
@@ -174,7 +174,7 @@ def show_pypi_plugins(installed_plugins, console):
         link = urljoin(api_url, snippet.get("href"))
         package = re.sub(r"\s+", " ", snippet.select_one('span[class*="name"]').text.strip())
         version = re.sub(r"\s+", " ", snippet.select_one('span[class*="version"]').text.strip())
-        released = re.sub(r"\s+", " ", snippet.select_one('span[class*="released"]').text.strip())
+        created = re.sub(r"\s+", " ", snippet.select_one('span[class*="created"]').text.strip())
         description = re.sub(r"\s+", " ", snippet.select_one('p[class*="description"]').text.strip())
         emoji = ":open_file_folder:"
 
@@ -189,7 +189,7 @@ def show_pypi_plugins(installed_plugins, console):
 
         table.add_row(
             f"[link={link}]{emoji}[/link] {package}",
-            description, version, released, installed,
+            description, version, created, installed,
         )
 
     console.print("\n")


### PR DESCRIPTION
This PR fixes Issue #92. It appears that the format of the data from PyPI has changed. There is no longer a `released` field, but there is a `created` field. This PR simply replaces the `released` field with the `created` field. 