### PR TITLE
Send GPS Beacon from webchat interface

### DIFF
--- a/aprsd/clients/kiss.py
+++ b/aprsd/clients/kiss.py
@@ -91,21 +91,29 @@ class KISS3Client:
         #     payload
         # )).encode('US-ASCII'),
         # payload = str(msg).encode('US-ASCII')
+        payload = None
+        path = ["WIDE1-1", "WIDE2-1"]
         if isinstance(msg, messaging.AckMessage):
             msg_payload = f"ack{msg.id}"
+        elif isinstance(msg, messaging.RawMessage):
+            payload = msg.message.encode("US-ASCII")
+            path = ["WIDE2-1"]
         else:
             msg_payload = f"{msg.message}{{{str(msg.id)}"
-        payload = (
-            ":{:<9}:{}".format(
-                msg.tocall,
-                msg_payload,
-            )
-        ).encode("US-ASCII")
+
+        if not payload:
+            payload = (
+                ":{:<9}:{}".format(
+                    msg.tocall,
+                    msg_payload,
+                )
+            ).encode("US-ASCII")
+
         LOG.debug(f"Send '{payload}' TO KISS")
         frame = Frame.ui(
             destination=msg.tocall,
             source=msg.fromcall,
-            path=["WIDE1-1", "WIDE2-1"],
+            path=path,
             info=payload,
         )
         self.kiss.write(frame)

--- a/aprsd/web/chat/static/js/send-message.js
+++ b/aprsd/web/chat/static/js/send-message.js
@@ -1,11 +1,11 @@
 var cleared = false;
 var callsign_list = {};
 var message_list = {};
+const socket = io("/sendmsg");
 
 function size_dict(d){c=0; for (i in d) ++c; return c}
 
 function init_chat() {
-   const socket = io("/sendmsg");
    socket.on('connect', function () {
        console.log("Connected to socketio");
    });
@@ -44,6 +44,54 @@ function init_chat() {
        socket.emit("send", msg);
        $('#message').val('');
    });
+
+   $("#send_beacon").click(function() {
+       console.log("Send a beacon!")
+       getLocation();
+   });
+}
+
+function getLocation() {
+    if (navigator.geolocation) {
+        console.log("getCurrentPosition");
+        navigator.geolocation.getCurrentPosition(showPosition, showError);
+    } else {
+        var msg = "Geolocation is not supported by this browser."
+        console.log(msg);
+        alert(msg)
+    }
+}
+
+function showError(error) {
+    console.log("showError");
+    console.log(error);
+    var msg = "";
+      switch(error.code) {
+        case error.PERMISSION_DENIED:
+          msg = "User denied the request for Geolocation."
+          break;
+        case error.POSITION_UNAVAILABLE:
+          msg = "Location information is unavailable."
+          break;
+        case error.TIMEOUT:
+          msg = "The request to get user location timed out."
+          break;
+        case error.UNKNOWN_ERROR:
+          msg = "An unknown error occurred."
+          break;
+      }
+      console.log(msg);
+      alert(msg);
+}
+
+function showPosition(position) {
+  console.log("showPosition Called");
+  msg = {
+      'latitude': position.coords.latitude,
+      'longitude': position.coords.longitude
+  }
+  console.log(msg);
+  socket.emit("gps", msg);
 }
 
 

--- a/aprsd/web/chat/templates/index.html
+++ b/aprsd/web/chat/templates/index.html
@@ -63,6 +63,7 @@
                         <input type="text" name="message" id="message" size="40" maxlength="40">
                     </div>
                     <input type="submit" name="submit" class="ui button" id="send_msg" value="Send" />
+                    <button type="button" class="ui button" id="send_beacon" value="Send GPS Beacon">Send GPS Beacon</button>
                 </form>
             </div>
             </div>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ENV LANG=C.UTF-8
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
-RUN apt install -y git build-essential rustc cargo
+RUN apt install -y git build-essential
 RUN apt install -y libffi-dev python3-dev libssl-dev libxml2-dev libxslt-dev
 RUN apt install -y python3 python3-pip python3-dev python3-lxml
 


### PR DESCRIPTION
This patchset allow getting the GPS coordinates from the browser's
geolocation API (which can be denied by user), then send's the GPS
coordinates to aprsd via socketio and then aprsd sends a beacon.

This allows the APRS network to know the location of the person running
the webchat app via browser so packets can get routed back to it.