### PR TITLE
Example plugin wrong function

### DIFF
--- a/examples/plugins/example_plugin.py
+++ b/examples/plugins/example_plugin.py
@@ -14,7 +14,7 @@ class HelloPlugin(plugin.APRSDRegexCommandPluginBase):
     command_regex = "^[hH]"
     command_name = "hello"
 
-    def command(self, packet):
+    def process(self, packet):
         LOG.info("HelloPlugin")
         reply = f"Hello '{packet.from_call}'"
         return reply


### PR DESCRIPTION
The example plugin, used verbatim, complains about an abstract class. The interface requires 'process'  not 'command'.