### PR TITLE
Fix sending packets over KISS interface

### DIFF
--- a/aprsd/stats.py
+++ b/aprsd/stats.py
@@ -246,7 +246,6 @@ class APRSDStats:
             },
             "plugins": plugin_stats,
         }
-        LOG.debug(f"STATS = {stats}")
         LOG.info("APRSD Stats: DONE")
         return stats
 


### PR DESCRIPTION
The KISS client sends the path as part of the headers, so we had to strip out the path from the payload of each message so the path wouldn't get listed twice.