### PR TITLE
Fix for dupe packets.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ CHANGES
 v3.2.0
 ------
 
+* Update Changelog for 3.2.0
 * minor cleanup prior to release
 * Webchat: fix input maxlength
 * WebChat: cleanup some console.logs

--- a/aprsd/clients/fake.py
+++ b/aprsd/clients/fake.py
@@ -1,0 +1,49 @@
+import logging
+import threading
+import time
+
+from oslo_config import cfg
+import wrapt
+
+from aprsd import conf  # noqa
+from aprsd.packets import core
+from aprsd.utils import trace
+
+
+CONF = cfg.CONF
+LOG = logging.getLogger("APRSD")
+
+
+class APRSDFakeClient(metaclass=trace.TraceWrapperMetaclass):
+    '''Fake client for testing.'''
+
+    # flag to tell us to stop
+    thread_stop = False
+
+    lock = threading.Lock()
+
+    def stop(self):
+        self.thread_stop = True
+        LOG.info("Shutdown APRSDFakeClient client.")
+
+    def is_alive(self):
+        """If the connection is alive or not."""
+        return not self.thread_stop
+
+    @wrapt.synchronized(lock)
+    def send(self, packet: core.Packet):
+        """Send an APRS Message object."""
+        LOG.info(f"Sending packet: {packet}")
+
+    def consumer(self, callback, blocking=False, immortal=False, raw=False):
+        LOG.debug("Start non blocking FAKE consumer")
+        # Generate packets here?
+        pkt = core.MessagePacket(
+            from_call="N0CALL",
+            to_call=CONF.callsign,
+            message_text="Hello World",
+            msgNo=13,
+        )
+        callback(packet=pkt)
+        LOG.debug(f"END blocking FAKE consumer {self}")
+        time.sleep(8)

--- a/aprsd/cmds/webchat.py
+++ b/aprsd/cmds/webchat.py
@@ -131,9 +131,9 @@ class WebChatProcessPacketThread(rx.APRSDProcessPacketThread):
     def process_ack_packet(self, packet: packets.AckPacket):
         super().process_ack_packet(packet)
         ack_num = packet.get("msgNo")
-        SentMessages().ack(int(ack_num))
+        SentMessages().ack(ack_num)
         self.socketio.emit(
-            "ack", SentMessages().get(int(ack_num)),
+            "ack", SentMessages().get(ack_num),
             namespace="/sendmsg",
         )
         self.got_ack = True

--- a/aprsd/conf/client.py
+++ b/aprsd/conf/client.py
@@ -19,6 +19,11 @@ kiss_tcp_group = cfg.OptGroup(
     name="kiss_tcp",
     title="KISS TCP/IP Device connection",
 )
+
+fake_client_group = cfg.OptGroup(
+    name="fake_client",
+    title="Fake Client settings",
+)
 aprs_opts = [
     cfg.BoolOpt(
         "enabled",
@@ -84,6 +89,14 @@ kiss_tcp_opts = [
     ),
 ]
 
+fake_client_opts = [
+    cfg.BoolOpt(
+        "enabled",
+        default=False,
+        help="Enable fake client connection.",
+    ),
+]
+
 
 def register_opts(config):
     config.register_group(aprs_group)
@@ -93,10 +106,14 @@ def register_opts(config):
     config.register_opts(kiss_serial_opts, group=kiss_serial_group)
     config.register_opts(kiss_tcp_opts, group=kiss_tcp_group)
 
+    config.register_group(fake_client_group)
+    config.register_opts(fake_client_opts, group=fake_client_group)
+
 
 def list_opts():
     return {
         aprs_group.name: aprs_opts,
         kiss_serial_group.name: kiss_serial_opts,
         kiss_tcp_group.name: kiss_tcp_opts,
+        fake_client_group.name: fake_client_opts,
     }

--- a/aprsd/packets/__init__.py
+++ b/aprsd/packets/__init__.py
@@ -1,6 +1,6 @@
 from aprsd.packets.core import (  # noqa: F401
-    AckPacket, GPSPacket, MessagePacket, MicEPacket, Packet, PathPacket,
-    RejectPacket, StatusPacket, WeatherPacket,
+    AckPacket, GPSPacket, MessagePacket, MicEPacket, Packet, RejectPacket,
+    StatusPacket, WeatherPacket,
 )
 from aprsd.packets.packet_list import PacketList  # noqa: F401
 from aprsd.packets.seen_list import SeenList  # noqa: F401

--- a/aprsd/packets/core.py
+++ b/aprsd/packets/core.py
@@ -33,6 +33,7 @@ def _init_timestamp():
     """Build a unix style timestamp integer"""
     return int(round(time.time()))
 
+
 def _init_msgNo():    # noqa: N802
     """For some reason __post__init doesn't get called.
 

--- a/aprsd/packets/packet_list.py
+++ b/aprsd/packets/packet_list.py
@@ -1,10 +1,11 @@
+from collections import MutableMapping, OrderedDict
 import logging
 import threading
 
 from oslo_config import cfg
 import wrapt
 
-from aprsd import stats, utils
+from aprsd import stats
 from aprsd.packets import seen_list
 
 
@@ -12,31 +13,24 @@ CONF = cfg.CONF
 LOG = logging.getLogger("APRSD")
 
 
-class PacketList:
-    """Class to track all of the packets rx'd and tx'd by aprsd."""
-
+class PacketList(MutableMapping):
     _instance = None
     lock = threading.Lock()
-
-    packet_list: utils.RingBuffer = utils.RingBuffer(1000)
-
     _total_rx: int = 0
     _total_tx: int = 0
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
+            cls._maxlen = 1000
+            cls.d = OrderedDict()
         return cls._instance
-
-    @wrapt.synchronized(lock)
-    def __iter__(self):
-        return iter(self.packet_list)
 
     @wrapt.synchronized(lock)
     def rx(self, packet):
         """Add a packet that was received."""
         self._total_rx += 1
-        self.packet_list.append(packet)
+        self._add(packet)
         seen_list.SeenList().update_seen(packet)
         stats.APRSDStats().rx(packet)
 
@@ -44,13 +38,46 @@ class PacketList:
     def tx(self, packet):
         """Add a packet that was received."""
         self._total_tx += 1
-        self.packet_list.append(packet)
+        self._add(packet)
         seen_list.SeenList().update_seen(packet)
         stats.APRSDStats().tx(packet)
 
     @wrapt.synchronized(lock)
-    def get(self):
-        return self.packet_list.get()
+    def add(self, packet):
+        self._add(packet)
+
+    def _add(self, packet):
+        key = packet.key()
+        self[key] = packet
+
+    @property
+    def maxlen(self):
+        return self._maxlen
+
+    @wrapt.synchronized(lock)
+    def find(self, packet):
+        key = packet.key()
+        return self.get(key)
+
+    def __getitem__(self, key):
+        #self.d.move_to_end(key)
+        return self.d[key]
+
+    def __setitem__(self, key, value):
+        if key in self.d:
+            self.d.move_to_end(key)
+        elif len(self.d) == self.maxlen:
+            self.d.popitem(last=False)
+        self.d[key] = value
+
+    def __delitem__(self, key):
+        del self.d[key]
+
+    def __iter__(self):
+        return self.d.__iter__()
+
+    def __len__(self):
+        return len(self.d)
 
     @wrapt.synchronized(lock)
     def total_rx(self):

--- a/aprsd/packets/packet_list.py
+++ b/aprsd/packets/packet_list.py
@@ -48,8 +48,7 @@ class PacketList(MutableMapping):
         self._add(packet)
 
     def _add(self, packet):
-        key = packet.key()
-        self[key] = packet
+        self[packet.key] = packet
 
     @property
     def maxlen(self):
@@ -57,8 +56,7 @@ class PacketList(MutableMapping):
 
     @wrapt.synchronized(lock)
     def find(self, packet):
-        key = packet.key()
-        return self.get(key)
+        return self.get(packet.key)
 
     def __getitem__(self, key):
         # self.d.move_to_end(key)

--- a/aprsd/packets/packet_list.py
+++ b/aprsd/packets/packet_list.py
@@ -60,7 +60,7 @@ class PacketList(MutableMapping):
         return self.get(key)
 
     def __getitem__(self, key):
-        #self.d.move_to_end(key)
+        # self.d.move_to_end(key)
         return self.d[key]
 
     def __setitem__(self, key, value):

--- a/aprsd/packets/packet_list.py
+++ b/aprsd/packets/packet_list.py
@@ -1,4 +1,5 @@
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import MutableMapping
 import logging
 import threading
 

--- a/aprsd/packets/tracker.py
+++ b/aprsd/packets/tracker.py
@@ -72,18 +72,17 @@ class PacketTrack(objectstore.ObjectStoreMixin):
 
     @wrapt.synchronized(lock)
     def add(self, packet):
-        key = int(packet.msgNo)
+        key = packet.msgNo
         self.data[key] = packet
         self.total_tracked += 1
 
     @wrapt.synchronized(lock)
-    def get(self, id):
-        if id in self.data:
-            return self.data[id]
+    def get(self, key):
+        if key in self.data:
+            return self.data[key]
 
     @wrapt.synchronized(lock)
-    def remove(self, id):
-        key = int(id)
+    def remove(self, key):
         if key in self.data.keys():
             del self.data[key]
 

--- a/aprsd/packets/tracker.py
+++ b/aprsd/packets/tracker.py
@@ -63,14 +63,6 @@ class PacketTrack(objectstore.ObjectStoreMixin):
         return len(self.data)
 
     @wrapt.synchronized(lock)
-    def __str__(self):
-        result = "{"
-        for key in self.data.keys():
-            result += f"{key}: {str(self.data[key])}, "
-        result += "}"
-        return result
-
-    @wrapt.synchronized(lock)
     def add(self, packet):
         key = packet.msgNo
         self.data[key] = packet
@@ -78,13 +70,14 @@ class PacketTrack(objectstore.ObjectStoreMixin):
 
     @wrapt.synchronized(lock)
     def get(self, key):
-        if key in self.data:
-            return self.data[key]
+        return self.data.get(key, None)
 
     @wrapt.synchronized(lock)
     def remove(self, key):
-        if key in self.data.keys():
+        try:
             del self.data[key]
+        except KeyError:
+            pass
 
     def restart(self):
         """Walk the list of messages and restart them if any."""

--- a/aprsd/threads/rx.py
+++ b/aprsd/threads/rx.py
@@ -93,7 +93,7 @@ class APRSDPluginRXThread(APRSDRXThread):
             pkt_list = packets.PacketList()
             try:
                 # Find the packet in the list of already seen packets
-                # Based on the packet.key()
+                # Based on the packet.key
                 found = pkt_list.find(packet)
             except KeyError:
                 found = False

--- a/aprsd/threads/rx.py
+++ b/aprsd/threads/rx.py
@@ -70,8 +70,14 @@ class APRSDPluginRXThread(APRSDRXThread):
         packet = self._client.decode_packet(*args, **kwargs)
         # LOG.debug(raw)
         packet.log(header="RX")
-        packets.PacketList().rx(packet)
-        self.packet_queue.put(packet)
+        tracked = packets.PacketTrack().get(packet.msgNo)
+        if not tracked:
+            # If we are in the process of already ack'ing
+            # a packet, we should drop the packet
+            # because it's a dupe within the time that
+            # we send the 3 acks for the packet.
+            packets.PacketList().rx(packet)
+            self.packet_queue.put(packet)
 
 
 class APRSDProcessPacketThread(APRSDThread):

--- a/aprsd/threads/rx.py
+++ b/aprsd/threads/rx.py
@@ -85,7 +85,7 @@ class APRSDPluginRXThread(APRSDRXThread):
             pkt_list.rx(packet)
             self.packet_queue.put(packet)
         elif packet.timestamp - found.timestamp < 60:
-                LOG.warning(f"Packet {packet.from_call}:{packet.msgNo} already tracked, dropping.")
+            LOG.warning(f"Packet {packet.from_call}:{packet.msgNo} already tracked, dropping.")
         else:
             LOG.warning(f"Packet {packet.from_call}:{packet.msgNo} already tracked but older than 60 seconds. processing.")
             pkt_list.rx(packet)

--- a/aprsd/threads/rx.py
+++ b/aprsd/threads/rx.py
@@ -78,6 +78,8 @@ class APRSDPluginRXThread(APRSDRXThread):
             # we send the 3 acks for the packet.
             packets.PacketList().rx(packet)
             self.packet_queue.put(packet)
+        else:
+            LOG.warning(f"Packet {packet.from_call}:{packet.msgNo} already tracked, dropping.")
 
 
 class APRSDProcessPacketThread(APRSDThread):

--- a/aprsd/utils/counter.py
+++ b/aprsd/utils/counter.py
@@ -37,7 +37,7 @@ class PacketCounter:
     @property
     @wrapt.synchronized(lock)
     def value(self):
-        return self.val.value
+        return str(self.val.value)
 
     @wrapt.synchronized(lock)
     def __repr__(self):

--- a/aprsd/web/chat/static/js/send-message.js
+++ b/aprsd/web/chat/static/js/send-message.js
@@ -34,7 +34,6 @@ function init_chat() {
        console.log("SENT: ");
        console.log(msg);
        if (cleared === false) {
-           console.log("CLEARING #msgsTabsDiv");
            var msgsdiv = $("#msgsTabsDiv");
            msgsdiv.html('');
            cleared = true;


### PR DESCRIPTION
Sometimes over KISS clients (RF), we can get duplicate packets due to having many digipeters in range of the TNC that aprsd is
connected to.   We will now filter out any dupe packets that aprsd
is still in the process of doing it's 3 acks.