### PR TITLE
aprsd: main.py: Fix premature return in sample_config

### DIFF
--- a/aprsd/main.py
+++ b/aprsd/main.py
@@ -146,8 +146,8 @@ def sample_config(ctx):
             raise SystemExit
         raise
     LOG.warning(conf.namespace)
-    return
     generator.generate(conf)
+    return
 
 
 @cli.command()


### PR DESCRIPTION
Fix a typo in `sample_config` that causes the function to return before config is generated.

This commit fixes  #143.