### PR TITLE
feat: Add configurable stale_timeout for APRS-IS connections

### DIFF
--- a/aprsd/client/drivers/aprsis.py
+++ b/aprsd/client/drivers/aprsis.py
@@ -32,8 +32,12 @@ class APRSISDriver:
     connected = False
 
     def __init__(self):
-        max_timeout = {'hours': 0.0, 'minutes': 2, 'seconds': 0}
-        self.max_delta = datetime.timedelta(**max_timeout)
+        # Use configurable stale_timeout, defaulting to 120 seconds if not set
+        try:
+            stale_timeout = CONF.aprs_network.stale_timeout
+        except (cfg.NoSuchOptError, cfg.NoSuchGroupError):
+            stale_timeout = 120  # Default to 2 minutes for backward compatibility
+        self.max_delta = datetime.timedelta(seconds=stale_timeout)
         self.login_status = {
             'success': False,
             'message': None,

--- a/aprsd/conf/client.py
+++ b/aprsd/conf/client.py
@@ -47,6 +47,14 @@ aprs_opts = [
         default=14580,
         help='APRS-IS port',
     ),
+    cfg.IntOpt(
+        'stale_timeout',
+        default=120,
+        help='Seconds without receiving data before connection is considered stale. '
+        'When a connection goes stale, it will be automatically reconnected. '
+        'Lower values detect dead connections faster but may cause unnecessary '
+        'reconnects during brief network hiccups. Default is 120 seconds (2 minutes).',
+    ),
 ]
 
 kiss_serial_opts = [

--- a/tests/client/drivers/test_aprsis_driver.py
+++ b/tests/client/drivers/test_aprsis_driver.py
@@ -83,11 +83,11 @@ class TestAPRSISDriver(unittest.TestCase):
         # Set a custom stale_timeout
         self.mock_conf.aprs_network.stale_timeout = 60  # 1 minute
 
-        # Create a new driver instance with custom timeout
-        driver = APRSISDriver.__new__(APRSISDriver)
-        driver.__init__()
+        # Re-initialize the existing driver with new config
+        # (singleton pattern means we can't create a new instance)
+        self.driver.__init__()
 
-        self.assertEqual(driver.max_delta, datetime.timedelta(seconds=60))
+        self.assertEqual(self.driver.max_delta, datetime.timedelta(seconds=60))
 
     def test_is_enabled_true(self):
         """Test is_enabled returns True when APRS-IS is enabled."""

--- a/tests/client/drivers/test_aprsis_driver.py
+++ b/tests/client/drivers/test_aprsis_driver.py
@@ -80,14 +80,22 @@ class TestAPRSISDriver(unittest.TestCase):
 
     def test_init_custom_stale_timeout(self):
         """Test initialization with custom stale_timeout."""
-        # Set a custom stale_timeout
-        self.mock_conf.aprs_network.stale_timeout = 60  # 1 minute
+        # Save original max_delta
+        original_max_delta = self.driver.max_delta
 
-        # Re-initialize the existing driver with new config
-        # (singleton pattern means we can't create a new instance)
-        self.driver.__init__()
+        try:
+            # Set a custom stale_timeout
+            self.mock_conf.aprs_network.stale_timeout = 60  # 1 minute
 
-        self.assertEqual(self.driver.max_delta, datetime.timedelta(seconds=60))
+            # Re-initialize the existing driver with new config
+            # (singleton pattern means we can't create a new instance)
+            self.driver.__init__()
+
+            self.assertEqual(self.driver.max_delta, datetime.timedelta(seconds=60))
+        finally:
+            # Restore original max_delta so other tests aren't affected
+            self.driver.max_delta = original_max_delta
+            self.mock_conf.aprs_network.stale_timeout = 120
 
     def test_is_enabled_true(self):
         """Test is_enabled returns True when APRS-IS is enabled."""

--- a/tests/client/drivers/test_aprsis_driver.py
+++ b/tests/client/drivers/test_aprsis_driver.py
@@ -24,6 +24,7 @@ class TestAPRSISDriver(unittest.TestCase):
         self.mock_conf.aprs_network.password = '12345'
         self.mock_conf.aprs_network.host = 'rotate.aprs.net'
         self.mock_conf.aprs_network.port = 14580
+        self.mock_conf.aprs_network.stale_timeout = 120  # Default 2 minutes
 
         # Mock APRS Lib Client
         self.aprslib_patcher = mock.patch('aprsd.client.drivers.aprsis.APRSLibClient')
@@ -71,10 +72,22 @@ class TestAPRSISDriver(unittest.TestCase):
     def test_init(self):
         """Test initialization sets default values."""
         self.assertIsInstance(self.driver.max_delta, datetime.timedelta)
-        self.assertEqual(self.driver.max_delta, datetime.timedelta(minutes=2))
+        # Default stale_timeout is 120 seconds (2 minutes)
+        self.assertEqual(self.driver.max_delta, datetime.timedelta(seconds=120))
         self.assertFalse(self.driver.login_status['success'])
         self.assertIsNone(self.driver.login_status['message'])
         self.assertIsNone(self.driver._client)
+
+    def test_init_custom_stale_timeout(self):
+        """Test initialization with custom stale_timeout."""
+        # Set a custom stale_timeout
+        self.mock_conf.aprs_network.stale_timeout = 60  # 1 minute
+
+        # Create a new driver instance with custom timeout
+        driver = APRSISDriver.__new__(APRSISDriver)
+        driver.__init__()
+
+        self.assertEqual(driver.max_delta, datetime.timedelta(seconds=60))
 
     def test_is_enabled_true(self):
         """Test is_enabled returns True when APRS-IS is enabled."""


### PR DESCRIPTION
## Summary
Add configurable `stale_timeout` for APRS-IS connections to allow faster detection of dead connections.

## Problem
The stale connection threshold is hardcoded to 2 minutes in `APRSISDriver.__init__()`. In production environments using the `listen` command with MQTT plugin, I observed connection stalls occurring every 6-7 minutes. The 2-minute detection delay results in significant data loss (~9 reconnects/hour with 2+ minutes of lost data each time).

The issue appears to be silent TCP connection failures to APRS-IS servers where the socket stays "connected" but no data flows. The TCP keepalive settings don't help because the connection isn't truly dead - it's just that data stops flowing (possibly due to APRS2.net load balancer behavior, NAT timeouts, or network issues).

## Solution
Add a `stale_timeout` configuration option that defaults to 120 seconds for backward compatibility but allows users to reduce it for faster recovery.

### Changes:
- **aprsd/conf/client.py**: Add `stale_timeout` config option (default: 120 seconds)
- **aprsd/client/drivers/aprsis.py**: Update `APRSISDriver.__init__` to use the config value with backward compatibility fallback
- **tests/client/drivers/test_aprsis_driver.py**: Update tests to handle the new configuration

## Usage
```ini
[aprs_network]
stale_timeout = 60  # Reconnect after 60 seconds without data
```

## Backward Compatibility
The default remains 120 seconds (2 minutes), and if the option is not present in the config, the code falls back to the same default. This ensures existing configurations continue to work without changes.