### PR TITLE
fix: write object stores atomically

### DIFF
--- a/aprsd/utils/objectstore.py
+++ b/aprsd/utils/objectstore.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+import tempfile
 
 from oslo_config import cfg
 
@@ -89,8 +90,24 @@ class ObjectStoreMixin:
                 f'{save_filename}',
             )
             with self.lock:
-                with open(save_filename, 'w') as fp:
-                    json.dump(self.data, fp, cls=SimpleJSONEncoder, indent=2)
+                temporary_path = None
+                try:
+                    with tempfile.NamedTemporaryFile(
+                        mode='w',
+                        dir=os.path.dirname(save_filename),
+                        prefix=f'.{os.path.basename(save_filename)}.',
+                        suffix='.tmp',
+                        delete=False,
+                    ) as fp:
+                        temporary_path = fp.name
+                        json.dump(self.data, fp, cls=SimpleJSONEncoder, indent=2)
+                        fp.flush()
+                        os.fsync(fp.fileno())
+                    os.replace(temporary_path, save_filename)
+                except Exception:
+                    if temporary_path and os.path.exists(temporary_path):
+                        os.unlink(temporary_path)
+                    raise
         else:
             LOG.debug(
                 "{} Nothing to save, flushing old save file '{}'".format(

--- a/tests/utils/test_objectstore.py
+++ b/tests/utils/test_objectstore.py
@@ -98,6 +98,26 @@ class TestObjectStoreMixin(unittest.TestCase):
         self.assertIn('testobjectstore', filename.lower())
         self.assertTrue(filename.endswith('.json'))
 
+    def test_save_uses_atomic_replace(self):
+        """Save writes a complete file through a temporary replacement."""
+        obj = TestObjectStore()
+        obj.data['key1'] = 'value1'
+
+        original_replace = os.replace
+
+        def replace(source, target):
+            original_replace(source, target)
+
+        with mock.patch(
+            'aprsd.utils.objectstore.os.replace', side_effect=replace
+        ) as mock_replace:
+            obj.save()
+
+        mock_replace.assert_called_once()
+        temporary_path, target_path = mock_replace.call_args.args
+        self.assertEqual(target_path, obj._save_filename())
+        self.assertFalse(os.path.exists(temporary_path))
+
     def test_save(self):
         """Test save() method."""
         obj = TestObjectStore()


### PR DESCRIPTION
## Summary

`ObjectStoreMixin.save()` opened the destination with `open(..., "w")` and serialized JSON directly to it. This PR writes to a same-directory temporary file, flushes and fsyncs it, then atomically replaces the destination with `os.replace()`.

This addresses the malformed `statsstore.json` event reported by APRSD issue 9 in `hemna/aprsd-irc-extension`.

## Verification

- `PYTHONHASHSEED=0 .venv/bin/python -m pytest -q -p no:libtmux` — 729 passed
- `.venv/bin/ruff check aprsd tests` — All checks passed
- pre-commit hooks — Passed
- `git diff --check` — clean