### PR TITLE
Fix obsolete pickle migration warning

### DIFF
--- a/aprsd/utils/objectstore.py
+++ b/aprsd/utils/objectstore.py
@@ -130,7 +130,6 @@ class ObjectStoreMixin:
             if not os.path.exists(json_file) and os.path.exists(pickle_file):
                 LOG.warning(
                     f'{self.__class__.__name__}::Found old pickle file {pickle_file}. '
-                    f'Please run "aprsd dev migrate-pickle" to convert to JSON format. '
                     f'Skipping load to avoid security risk.'
                 )
                 return

--- a/tests/utils/test_objectstore.py
+++ b/tests/utils/test_objectstore.py
@@ -324,4 +324,4 @@ class TestObjectStoreMixin(unittest.TestCase):
             mock_log.warning.assert_called()
             call_args = str(mock_log.warning.call_args)
             self.assertIn('pickle', call_args.lower())
-            self.assertIn('migrate', call_args.lower())
+            self.assertNotIn('migrate-pickle', call_args.lower())


### PR DESCRIPTION
## Summary
- Remove the unavailable `aprsd dev migrate-pickle` instruction from the legacy pickle warning.
- Keep the security-safe skipped-load behavior.
- Update the regression test to ensure the obsolete command is absent.

## Release
Intended for 5.0.1.

## Verification
- `uv run --extra tests pytest tests/utils/test_objectstore.py -q`
- `uv run --extra tests ruff check aprsd/utils/objectstore.py tests/utils/test_objectstore.py`
- Pre-commit hooks passed.