### PR TITLE
fix: guard against malformed Reply-Ack packets

### DIFF
--- a/aprsd/threads/rx.py
+++ b/aprsd/threads/rx.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 import queue
+import re
 
 import aprslib
 from oslo_config import cfg
@@ -244,6 +245,34 @@ class APRSDProcessPacketThread(APRSDFilterThread):
         ):
             self.process_reject_packet(packet)
         else:
+            malformed_ack = None
+            if (
+                isinstance(packet, packets.MessagePacket)
+                and to_call
+                and to_call.lower() == our_call
+                and packet.message_text
+            ):
+                malformed_ack = re.fullmatch(
+                    r'ack([A-Za-z0-9]+)\}[A-Za-z0-9]+',
+                    packet.message_text,
+                    re.IGNORECASE,
+                )
+
+            if malformed_ack:
+                LOG.warning(
+                    'Received malformed Reply-Ack %r; acknowledging message %s',
+                    packet.message_text,
+                    malformed_ack.group(1),
+                )
+                self.process_ack_packet(
+                    packets.AckPacket(
+                        from_call=packet.from_call,
+                        to_call=packet.addresse,
+                        msgNo=malformed_ack.group(1),
+                    ),
+                )
+                return False
+
             if hasattr(packet, 'ackMsgNo') and packet.ackMsgNo:
                 # we got an ack embedded in this packet
                 # we need to handle the ack

--- a/tests/threads/test_rx.py
+++ b/tests/threads/test_rx.py
@@ -364,6 +364,36 @@ class TestAPRSDProcessPacketThread(unittest.TestCase):
             self.process_thread.process_ack_packet(packet)
             mock_rx.assert_called_with(packet)
 
+    def test_malformed_reply_ack_does_not_dispatch_as_command(self):
+        """Treat an appending-piggyback ACK as an ACK, not a command."""
+        from oslo_config import cfg
+
+        from aprsd import packets
+        from aprsd.threads import tx
+
+        CONF = cfg.CONF
+        CONF.callsign = 'TEST'
+        packet = fake.fake_packet(
+            fromcall='KJ4ERJ',
+            tocall='TEST',
+            message='ack3677}67392',
+        )
+
+        with (
+            mock.patch.object(self.process_thread, 'process_ack_packet') as mock_ack,
+            mock.patch.object(
+                self.process_thread, 'process_our_message_packet'
+            ) as mock_plugin,
+            mock.patch.object(tx, 'send') as mock_send,
+        ):
+            self.process_thread.process_packet(packet)
+
+        ack_packet = mock_ack.call_args.args[0]
+        self.assertIsInstance(ack_packet, packets.AckPacket)
+        self.assertEqual(ack_packet.msgNo, '3677')
+        mock_plugin.assert_not_called()
+        mock_send.assert_not_called()
+
     def test_process_piggyback_ack(self):
         """Test process_piggyback_ack() method."""
         from aprsd.packets import collector


### PR DESCRIPTION
## Summary

Guard aprsd against malformed ACK packets emitted by mobile APRS clients for Reply-Ack messages.

## Packet sequence

A valid JOKE response is:

```text
Whoawhoawewa!{3677}67392
```

The affected client emitted:

```text
ack3677}67392
```

`3677` is the outbound message ID being acknowledged. The trailing `}67392` is not part of the ACK payload.

## Change

Recognize the malformed `ack<id>}<id>` form at the receive boundary, clear the acknowledged outbound message, and stop it from entering command-plugin dispatch or generating another ACK.

The mobile clients still need their parser fix. This aprsd guard prevents malformed ACK traffic from producing `Unknown command!` replies.

## Verification

- `730 passed`
- Ruff passed
- Pre-commit hooks passed
